### PR TITLE
chore: Streamline console logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,12 @@ pip install swift-book-pdf
 ## Usage
 ### Basic usage
 Call `swift_book_pdf` without any arguments to save the resulting PDF as `swift_book.pdf` in the current directory. The package defaults to the digital [rendering mode](#rendering-modes).
-```
-swift_book_pdf
+```bash
+$ swift_book_pdf
+
+[INFO]: Downloading TSPL files...
+[INFO]: Creating PDF in digital mode...
+[INFO]: PDF saved to ./swift-book.pdf
 ```
 
 When invoked, `swift_book_pdf` will:

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ pip install swift-book-pdf
 ## Usage
 ### Basic usage
 Call `swift_book_pdf` without any arguments to save the resulting PDF as `swift_book.pdf` in the current directory. The package defaults to the digital [rendering mode](#rendering-modes).
-```bash
+```
 $ swift_book_pdf
 
 [INFO]: Downloading TSPL files...

--- a/swift_book_pdf/book.py
+++ b/swift_book_pdf/book.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import logging
 
 from tqdm import trange
 from swift_book_pdf.config import Config
@@ -20,6 +21,8 @@ from swift_book_pdf.latex import LaTeXConverter
 from swift_book_pdf.pdf import PDFConverter
 from swift_book_pdf.preamble import generate_preamble
 from swift_book_pdf.toc import TableOfContents
+
+logger = logging.getLogger(__name__)
 
 
 class Book:
@@ -41,7 +44,7 @@ class Book:
                 latex_content = self.converter.generate_latex(file_path)
                 latex += latex_content + "\n"
             else:
-                self.config.logger.warning(
+                logger.warning(
                     f"Warning: No file found for tag <doc:{tag}>, skipping..."
                 )
         latex += r"\end{document}"
@@ -51,15 +54,15 @@ class Book:
     def process(self):
         latex_file_path = os.path.join(self.config.temp_dir, "inner_content.tex")
         self.process_files_in_order(latex_file_path)
-        self.config.logger.info("Creating PDF...")
+        logger.info(f"Creating PDF in {self.config.rendering_mode.value} mode...")
         converter = PDFConverter(self.config)
         for _ in trange(self.config.typesets, leave=False):
             converter.convert_to_pdf(latex_file_path)
 
         temp_pdf_path = os.path.join(self.config.temp_dir, "inner_content.pdf")
         if not os.path.exists(temp_pdf_path):
-            self.config.logger.error(f"PDF file not found: {temp_pdf_path}")
+            logger.error(f"PDF file not found: {temp_pdf_path}")
             return
 
         os.rename(temp_pdf_path, self.config.output_path)
-        self.config.logger.info(f"PDF saved to {self.config.output_path}")
+        logger.info(f"PDF saved to {self.config.output_path}")

--- a/swift_book_pdf/cli.py
+++ b/swift_book_pdf/cli.py
@@ -12,17 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from tempfile import TemporaryDirectory
 import click
 import logging
+
+from tempfile import TemporaryDirectory
 
 from swift_book_pdf.book import Book
 from swift_book_pdf.config import Config
 from swift_book_pdf.files import validate_output_path
 from swift_book_pdf.fonts import FontConfig
+from swift_book_pdf.log import configure_logging
 from swift_book_pdf.schema import RenderingMode
-
-logger = logging.getLogger(__name__)
 
 
 @click.group()
@@ -41,19 +41,19 @@ def cli() -> None:
 @click.option("--verbose", is_flag=True)
 @click.option("--typesets", type=int, default=4)
 def run(output_path: str, mode: str, verbose: bool, typesets: int) -> None:
-    logging.basicConfig(
-        level=logging.DEBUG if verbose else logging.INFO, format="%(message)s"
-    )
+    configure_logging(verbose)
+    logger = logging.getLogger(__name__)
+
     try:
-        output_path = validate_output_path(output_path, logger)
+        output_path = validate_output_path(output_path)
         font_config = FontConfig()
-        font_config.check_font_availability(logger)
+        font_config.check_font_availability()
     except ValueError as e:
         logger.error(str(e))
         return
 
     with TemporaryDirectory() as temp:
-        config = Config(temp, output_path, RenderingMode(mode), logger, typesets)
+        config = Config(temp, output_path, RenderingMode(mode), typesets)
         Book(config).process()
 
 

--- a/swift_book_pdf/config.py
+++ b/swift_book_pdf/config.py
@@ -18,6 +18,8 @@ import shutil
 from swift_book_pdf.files import clone_swift_book_repo
 from swift_book_pdf.schema import RenderingMode
 
+logger = logging.getLogger(__name__)
+
 
 class Config:
     def __init__(
@@ -25,17 +27,14 @@ class Config:
         input_path: str,
         output_path: str,
         output_format: RenderingMode,
-        logger: logging.Logger,
         typesets: int,
     ):
-        self.logger = logger
-
         if not shutil.which("git"):
             raise RuntimeError("Git is not installed or not in PATH.")
 
         self.temp_dir = input_path
 
-        self.logger.info("Downloading TSPL files...")
+        logger.info("Downloading TSPL files...")
         clone_swift_book_repo(input_path)
         self.root_dir = os.path.join(input_path, "swift-book/TSPL.docc/")
 

--- a/swift_book_pdf/files.py
+++ b/swift_book_pdf/files.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from logging import Logger
+import logging
 import os
 import subprocess
+
+logger = logging.getLogger(__name__)
 
 
 def get_file_name(file_path: str) -> str:
@@ -31,12 +33,17 @@ def clone_swift_book_repo(temp: str) -> None:
     repo_url = "https://github.com/swiftlang/swift-book.git"
     clone_dir = os.path.join(temp, "swift-book")
 
+    is_debug = logging.getLogger().isEnabledFor(logging.DEBUG)
+
     subprocess.run(
-        ["git", "clone", repo_url, clone_dir], check=True, stdout=subprocess.DEVNULL
+        ["git", "clone", repo_url, clone_dir],
+        check=True,
+        stdout=None if is_debug else subprocess.DEVNULL,
+        stderr=None if is_debug else subprocess.DEVNULL,
     )
 
 
-def validate_output_path(output_path: str, logger: Logger) -> str:
+def validate_output_path(output_path: str) -> str:
     output_dir = os.path.dirname(output_path) or "."  # Default to current directory
 
     if os.path.isdir(output_path):

--- a/swift_book_pdf/fonts.py
+++ b/swift_book_pdf/fonts.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from logging import Logger
+import logging
 import subprocess
+
+logger = logging.getLogger(__name__)
 
 SANS_FONT = "Helvetica Neue"
 SANS_FONT_BOLD = "Helvetica Neue Bold"
@@ -43,7 +45,7 @@ class FontConfig:
         self.unicode_font = unicode_font
         self.header_footer_font = header_footer_font
 
-    def check_font_availability(self, logger: Logger) -> None:
+    def check_font_availability(self) -> None:
         fonts = [
             self.sans_font,
             self.sans_font_bold,


### PR DESCRIPTION
Introduces improvements to console logging:
- When the log level is set to INFO, git clone logs are no longer presented.
- The “Creating PDF...” log line now displays the rendering mode.
- LaTeX scrolling logs now show up to 10 lines.
- When the log level is set to DEBUG, LaTeX logs are presented in full.