### PR TITLE
feat: Add support for different page sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Add CLI `--size` option to generate book in letter, legal, or A4 paper sizes.
+- Add CLI `--paper` option to generate book in letter, legal, or A4 paper sizes.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- Add CLI option to generate book in letter, legal, or A4 paper sizes.
+
 ## [1.0.2] - 2025-03-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,12 @@
 ## [Unreleased]
 
 ### Added
+
 - Add CLI option to generate book in letter, legal, or A4 paper sizes.
+
+### Changed
+
+- Changed the footer's bottom margin to mirror the header's top margin.
 
 ## [1.0.2] - 2025-03-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Add CLI option to generate book in letter, legal, or A4 paper sizes.
+- Add CLI `--size` option to generate book in letter, legal, or A4 paper sizes.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ pip install swift-book-pdf
 
 ## Usage
 ### Basic usage
-Call `swift_book_pdf` without any arguments to save the resulting PDF as `swift_book.pdf` in the current directory. The package defaults to the digital [rendering mode](#rendering-modes) in Letter [paper size](#paper-sizes).
+Call `swift_book_pdf` without any arguments to save the resulting PDF as `swift_book.pdf` in the current directory. The package defaults to the digital [rendering mode](#rendering-modes).
 ```
 $ swift_book_pdf
 
@@ -70,25 +70,15 @@ swift_book_pdf /path/to/output.pdf
 `swift_book_pdf` supports two rendering modes:
 
 1. `digital` (default): Best for browsing _The Swift Programming Language_ book as a PDF, the `digital` mode renders internal references and external links in blue hyperlinks.
+
+   ```
+   swift_book_pdf /path/to/output.pdf --mode digital
+   ```
 2. `print`: Best for reading through _The Swift Programming Language_ book in print, the `print` mode includes page numbers for all internal references and complete URLs in footnotes for external links.
 
-Use the `--mode` option to set your preferred rendering option:
-
-```
-swift_book_pdf /path/to/output.pdf --mode print
-```
-
-### Paper sizes
-`swift_book_pdf` supports three paper sizes:
-
-1. `letter` (default)
-2. `legal`
-3. `A4`
-
-Use the `--paper` option to set your preferred paper size:
-```
-swift_book_pdf --paper legal
-```
+   ```
+   swift_book_pdf /path/to/output.pdf --mode print
+   ```
 
 ### Number of typesetting passes
 This package uses LaTeX to typeset the TSPL book. LaTeX arranges page elements dynamically, so references added in the second pass may shift the page content, and alter the placement of headers and footers. To ensure everything is properly rendered, swift_book_pdf typesets the document four times.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ pip install swift-book-pdf
 
 ## Usage
 ### Basic usage
-Call `swift_book_pdf` without any arguments to save the resulting PDF as `swift_book.pdf` in the current directory. The package defaults to the digital [rendering mode](#rendering-modes).
+Call `swift_book_pdf` without any arguments to save the resulting PDF as `swift_book.pdf` in the current directory. The package defaults to the digital [rendering mode](#rendering-modes) in Letter [paper size](#paper-sizes).
 ```
 $ swift_book_pdf
 
@@ -70,15 +70,25 @@ swift_book_pdf /path/to/output.pdf
 `swift_book_pdf` supports two rendering modes:
 
 1. `digital` (default): Best for browsing _The Swift Programming Language_ book as a PDF, the `digital` mode renders internal references and external links in blue hyperlinks.
-
-   ```
-   swift_book_pdf /path/to/output.pdf --mode digital
-   ```
 2. `print`: Best for reading through _The Swift Programming Language_ book in print, the `print` mode includes page numbers for all internal references and complete URLs in footnotes for external links.
 
-   ```
-   swift_book_pdf /path/to/output.pdf --mode print
-   ```
+Use the `--mode` option to set your preferred rendering option:
+
+```
+swift_book_pdf /path/to/output.pdf --mode print
+```
+
+### Paper sizes
+`swift_book_pdf` supports three paper sizes:
+
+1. `letter` (default)
+2. `legal`
+3. `A4`
+
+Use the `--paper` option to set your preferred paper size:
+```
+swift_book_pdf --paper legal
+```
 
 ### Number of typesetting passes
 This package uses LaTeX to typeset the TSPL book. LaTeX arranges page elements dynamically, so references added in the second pass may shift the page content, and alter the placement of headers and footers. To ensure everything is properly rendered, swift_book_pdf typesets the document four times.

--- a/swift_book_pdf/book.py
+++ b/swift_book_pdf/book.py
@@ -32,7 +32,7 @@ class Book:
         self.converter = LaTeXConverter(config)
 
     def process_files_in_order(self, latex_file_path: str):
-        latex = generate_preamble(self.config.rendering_mode)
+        latex = generate_preamble(self.config.doc_config)
         # TODO: Use the version to generate a cover page
         toc_latex, _ = self.toc.generate_toc_latex(converter=self.converter)
         latex += toc_latex + "\n"
@@ -54,9 +54,9 @@ class Book:
     def process(self):
         latex_file_path = os.path.join(self.config.temp_dir, "inner_content.tex")
         self.process_files_in_order(latex_file_path)
-        logger.info(f"Creating PDF in {self.config.rendering_mode.value} mode...")
+        logger.info(f"Creating PDF in {self.config.doc_config.mode.value} mode...")
         converter = PDFConverter(self.config)
-        for _ in trange(self.config.typesets, leave=False):
+        for _ in trange(self.config.doc_config.typesets, leave=False):
             converter.convert_to_pdf(latex_file_path)
 
         temp_pdf_path = os.path.join(self.config.temp_dir, "inner_content.pdf")

--- a/swift_book_pdf/cli.py
+++ b/swift_book_pdf/cli.py
@@ -46,8 +46,10 @@ def cli() -> None:
     show_default="digital",
 )
 @click.option(
-    "--size",
-    type=click.Choice([size.value for size in PaperSize], case_sensitive=False),
+    "--paper",
+    type=click.Choice(
+        [paper_size.value for paper_size in PaperSize], case_sensitive=False
+    ),
     default=PaperSize.LETTER.value,
     help="Paper size for the document",
     show_default="letter",
@@ -60,7 +62,7 @@ def cli() -> None:
     show_default="4",
 )
 @click.option("--verbose", is_flag=True)
-def run(output_path: str, mode: str, verbose: bool, typesets: int, size: str) -> None:
+def run(output_path: str, mode: str, verbose: bool, typesets: int, paper: str) -> None:
     configure_logging(verbose)
     logger = logging.getLogger(__name__)
 
@@ -68,7 +70,7 @@ def run(output_path: str, mode: str, verbose: bool, typesets: int, size: str) ->
         output_path = validate_output_path(output_path)
         font_config = FontConfig()
         font_config.check_font_availability()
-        doc_config = DocConfig(RenderingMode(mode), PaperSize(size), typesets)
+        doc_config = DocConfig(RenderingMode(mode), PaperSize(paper), typesets)
     except ValueError as e:
         logger.error(str(e))
         return

--- a/swift_book_pdf/config.py
+++ b/swift_book_pdf/config.py
@@ -15,8 +15,8 @@
 import logging
 import os
 import shutil
+from swift_book_pdf.doc import DocConfig
 from swift_book_pdf.files import clone_swift_book_repo
-from swift_book_pdf.schema import RenderingMode
 
 logger = logging.getLogger(__name__)
 
@@ -26,8 +26,7 @@ class Config:
         self,
         input_path: str,
         output_path: str,
-        output_format: RenderingMode,
-        typesets: int,
+        doc_config: DocConfig,
     ):
         if not shutil.which("git"):
             raise RuntimeError("Git is not installed or not in PATH.")
@@ -53,5 +52,4 @@ class Config:
             )
 
         self.output_path = output_path
-        self.rendering_mode = output_format
-        self.typesets = typesets
+        self.doc_config = doc_config

--- a/swift_book_pdf/doc.py
+++ b/swift_book_pdf/doc.py
@@ -1,0 +1,22 @@
+# Copyright 2025 Evangelos Kassos
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from swift_book_pdf.schema import PaperSize, RenderingMode
+
+
+class DocConfig:
+    def __init__(self, mode: RenderingMode = RenderingMode.DIGITAL, paper_size: PaperSize = PaperSize.LETTER, typesets: int = 4):
+        self.mode = mode
+        self.paper_size = paper_size
+        self.typesets = typesets

--- a/swift_book_pdf/doc.py
+++ b/swift_book_pdf/doc.py
@@ -16,7 +16,12 @@ from swift_book_pdf.schema import PaperSize, RenderingMode
 
 
 class DocConfig:
-    def __init__(self, mode: RenderingMode = RenderingMode.DIGITAL, paper_size: PaperSize = PaperSize.LETTER, typesets: int = 4):
+    def __init__(
+        self,
+        mode: RenderingMode = RenderingMode.DIGITAL,
+        paper_size: PaperSize = PaperSize.LETTER,
+        typesets: int = 4,
+    ):
         self.mode = mode
         self.paper_size = paper_size
         self.typesets = typesets

--- a/swift_book_pdf/latex.py
+++ b/swift_book_pdf/latex.py
@@ -61,7 +61,7 @@ class LaTeXConverter:
         latex_lines.append("{\\BodyStyle\n")
         blocks = parse_blocks(file_content)
         body_latex = convert_blocks_to_latex(
-            blocks, file_name, self.config.assets_dir, self.config.rendering_mode
+            blocks, file_name, self.config.assets_dir, self.config.doc_config.mode
         )
         latex_lines.extend(body_latex)
         latex_lines.append("}\n\\newpage\n")

--- a/swift_book_pdf/preamble.py
+++ b/swift_book_pdf/preamble.py
@@ -49,7 +49,7 @@ PREAMBLE = Template(r"""
 \usepackage{xcolor}
 \usepackage{graphicx}
 \usepackage{fancyhdr}
-\usepackage[$geometry_opts,inner=1.9in,top=1.2in,outer=0.9in,headheight=0.8in,headsep=0.3in,bottom=1.2in]{geometry}
+\usepackage[$geometry_opts,top=1.2in,outer=0.9in,headheight=0.8in,headsep=0.3in,bottom=1.2in]{geometry}
 \usepackage{adjustbox}
 \usepackage{ifoddpage}
 \usepackage{enumitem}

--- a/swift_book_pdf/preamble.py
+++ b/swift_book_pdf/preamble.py
@@ -49,7 +49,7 @@ PREAMBLE = Template(r"""
 \usepackage{xcolor}
 \usepackage{graphicx}
 \usepackage{fancyhdr}
-\usepackage[$geometry_opts,inner=1.67in,top=1.2in,outer=0.9in,headheight=0.8in,headsep=0.3in,bottom=1.2in]{geometry}
+\usepackage[$geometry_opts,inner=1.9in,top=1.2in,outer=0.9in,headheight=0.8in,headsep=0.3in,bottom=1.2in]{geometry}
 \usepackage{adjustbox}
 \usepackage{ifoddpage}
 \usepackage{enumitem}

--- a/swift_book_pdf/preamble.py
+++ b/swift_book_pdf/preamble.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .schema import RenderingMode
+from swift_book_pdf.doc import DocConfig
+from .schema import PaperSize, RenderingMode
 from string import Template
 
 
@@ -26,8 +27,19 @@ def get_link_color(mode: RenderingMode) -> str:
             raise ValueError("Invalid rendering mode specified.")
 
 
-def generate_preamble(mode: RenderingMode) -> str:
-    return PREAMBLE.substitute(color=get_link_color(mode))
+def get_geometry_opts(paper_size: PaperSize) -> str:
+    return {
+        PaperSize.A4: "a4paper,inner=1.67in",
+        PaperSize.LETTER: "letterpaper,inner=1.9in",
+        PaperSize.LEGAL: "legalpaper,inner=1.9in",
+    }.get(paper_size, "letterpaper,inner=1.9in")
+
+
+def generate_preamble(doc_config: DocConfig) -> str:
+    return PREAMBLE.substitute(
+        color=get_link_color(doc_config.mode),
+        geometry_opts=get_geometry_opts(doc_config.paper_size),
+    )
 
 
 PREAMBLE = Template(r"""
@@ -37,7 +49,7 @@ PREAMBLE = Template(r"""
 \usepackage{xcolor}
 \usepackage{graphicx}
 \usepackage{fancyhdr}
-\usepackage[inner=1.9in,outer=0.9in,headheight=0.8in,headsep=0.3in,bottom=1.2in]{geometry}
+\usepackage[$geometry_opts,inner=1.67in,top=1.2in,outer=0.9in,headheight=0.8in,headsep=0.3in,bottom=1.2in]{geometry}
 \usepackage{adjustbox}
 \usepackage{ifoddpage}
 \usepackage{enumitem}
@@ -371,14 +383,14 @@ PREAMBLE = Template(r"""
 
 \fancyfoot[FO]{%
 \begin{tikzpicture}[remember picture, overlay]
-\fill[headerGray] ([yshift=0.4in]current page.south west)
- rectangle ([yshift=0.8in]current page.south east);
+\fill[headerGray] ([yshift=0.5in]current page.south west)
+ rectangle ([yshift=0.9in]current page.south east);
 
-\node[anchor=east] at ([yshift=0.6in,xshift=-0.7in]current page.south east) {
+\node[anchor=east] at ([yshift=0.7in,xshift=-0.7in]current page.south east) {
   \includegraphics[height=0.18in]{Swift_logo_white.png}
 };
 
-\node[anchor=east,white] at ([yshift=0.6in,xshift=-1in]current page.south east) {
+\node[anchor=east,white] at ([yshift=0.7in,xshift=-1in]current page.south east) {
   \fontspec{SF Compact Display} \fontsize{13pt}{0pt}\selectfont \thepage
 };
 \end{tikzpicture}%
@@ -386,14 +398,14 @@ PREAMBLE = Template(r"""
 
 \fancyfoot[FE]{%
 \begin{tikzpicture}[remember picture, overlay]
-\fill[headerGray] ([yshift=0.4in]current page.south west)
- rectangle ([yshift=0.8in]current page.south east);
+\fill[headerGray] ([yshift=0.5in]current page.south west)
+ rectangle ([yshift=0.9in]current page.south east);
 
-\node[anchor=west] at ([yshift=0.6in,xshift=0.7in]current page.south west) {
+\node[anchor=west] at ([yshift=0.7in,xshift=0.7in]current page.south west) {
   \includegraphics[height=0.18in]{Swift_logo_white.png}
 };
 
-\node[anchor=west,white] at ([yshift=0.6in,xshift=1in]current page.south west) {
+\node[anchor=west,white] at ([yshift=0.7in,xshift=1in]current page.south west) {
   \fontspec{SF Compact Display} \fontsize{13pt}{0pt}\selectfont \thepage
 };
 \end{tikzpicture}%
@@ -403,14 +415,14 @@ PREAMBLE = Template(r"""
   \fancyhf{}
   \fancyfoot[FO]{%
   \begin{tikzpicture}[remember picture, overlay]
-  \fill[headerGray] ([yshift=0.4in]current page.south west)
-   rectangle ([yshift=0.8in]current page.south east);
+  \fill[headerGray] ([yshift=0.5in]current page.south west)
+   rectangle ([yshift=0.9in]current page.south east);
 
-  \node[anchor=east] at ([yshift=0.6in,xshift=-0.7in]current page.south east) {
+  \node[anchor=east] at ([yshift=0.7in,xshift=-0.7in]current page.south east) {
     \includegraphics[height=0.18in]{Swift_logo_white.png}
   };
 
-  \node[anchor=east,white] at ([yshift=0.6in,xshift=-1in]current page.south east) {
+  \node[anchor=east,white] at ([yshift=0.7in,xshift=-1in]current page.south east) {
     \fontspec{SF Compact Display} \fontsize{13pt}{0pt}\selectfont \thepage
   };
   \end{tikzpicture}%
@@ -418,14 +430,14 @@ PREAMBLE = Template(r"""
 
   \fancyfoot[FE]{%
   \begin{tikzpicture}[remember picture, overlay]
-  \fill[headerGray] ([yshift=0.4in]current page.south west)
-   rectangle ([yshift=0.8in]current page.south east);
+  \fill[headerGray] ([yshift=0.5in]current page.south west)
+   rectangle ([yshift=0.9in]current page.south east);
 
-  \node[anchor=west] at ([yshift=0.6in,xshift=0.7in]current page.south west) {
+  \node[anchor=west] at ([yshift=0.7in,xshift=0.7in]current page.south west) {
     \includegraphics[height=0.18in]{Swift_logo_white.png}
   };
 
-  \node[anchor=west,white] at ([yshift=0.6in,xshift=1in]current page.south west) {
+  \node[anchor=west,white] at ([yshift=0.7in,xshift=1in]current page.south west) {
     \fontspec{SF Compact Display} \fontsize{13pt}{0pt}\selectfont \thepage
   };
   \end{tikzpicture}%

--- a/swift_book_pdf/schema.py
+++ b/swift_book_pdf/schema.py
@@ -22,6 +22,12 @@ class RenderingMode(StrEnum):
     PRINT = "print"
 
 
+class PaperSize(StrEnum):
+    A4 = "a4"
+    LETTER = "letter"
+    LEGAL = "legal"
+
+
 class ChapterMetadata(BaseModel):
     file_path: str | None = None
     header_line: str | None = None

--- a/swift_book_pdf/toc.py
+++ b/swift_book_pdf/toc.py
@@ -48,13 +48,13 @@ class TableOfContents:
     ) -> tuple[str, Optional[str]]:
         processed_lines = remove_directives(self.file_content)
         processed_lines = replace_chapter_href_with_toc_item(
-            processed_lines, self.chapter_metadata, converter.config.rendering_mode
+            processed_lines, self.chapter_metadata, converter.config.doc_config.mode
         )
         processed_lines, version_info = replace_and_extract_version(processed_lines)
         file_name = get_file_name(self.tspl_file_path)
         toc_latex_lines = converter.convert_file_to_latex(processed_lines, file_name)
         toc_latex_lines = self.toc_latex_overrides(
-            toc_latex_lines, converter.config.rendering_mode
+            toc_latex_lines, converter.config.doc_config.mode
         )
         toc_latex = "\n".join(toc_latex_lines)
         return toc_latex, version_info


### PR DESCRIPTION
Adds support for generating the TSPL book in legal and A4 sizes. Adds `—-size` CLI option to set the paper size. Changed the footer's bottom margin to mirror the header's top margin.

### Implementation details 
To maintain the same text box width, the book gutter for the A4 size has been decreased to 1.67 inches vs the standard 1.9 inch gutter in letter/legal paper sizes.