### PR TITLE
Add more default font choices for each required font category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added more default font options, organized in five font categories. swift-book-pdf will now typeset TSPL in any system where LuaTeX has access to at least one font in each font category.
+
 ## [1.1.0] - 2025-03-13
 
 ### Added

--- a/swift_book_pdf/book.py
+++ b/swift_book_pdf/book.py
@@ -32,7 +32,7 @@ class Book:
         self.converter = LaTeXConverter(config)
 
     def process_files_in_order(self, latex_file_path: str):
-        latex = generate_preamble(self.config.doc_config)
+        latex = generate_preamble(self.config)
         # TODO: Use the version to generate a cover page
         toc_latex, _ = self.toc.generate_toc_latex(converter=self.converter)
         latex += toc_latex + "\n"

--- a/swift_book_pdf/cli.py
+++ b/swift_book_pdf/cli.py
@@ -69,14 +69,13 @@ def run(output_path: str, mode: str, verbose: bool, typesets: int, paper: str) -
     try:
         output_path = validate_output_path(output_path)
         font_config = FontConfig()
-        font_config.check_font_availability()
         doc_config = DocConfig(RenderingMode(mode), PaperSize(paper), typesets)
     except ValueError as e:
         logger.error(str(e))
         return
 
     with TemporaryDirectory() as temp:
-        config = Config(temp, output_path, doc_config)
+        config = Config(temp, output_path, font_config, doc_config)
         Book(config).process()
 
 

--- a/swift_book_pdf/config.py
+++ b/swift_book_pdf/config.py
@@ -17,6 +17,7 @@ import os
 import shutil
 from swift_book_pdf.doc import DocConfig
 from swift_book_pdf.files import clone_swift_book_repo
+from swift_book_pdf.fonts import FontConfig
 
 logger = logging.getLogger(__name__)
 
@@ -26,6 +27,7 @@ class Config:
         self,
         input_path: str,
         output_path: str,
+        font_config: FontConfig,
         doc_config: DocConfig,
     ):
         if not shutil.which("git"):
@@ -52,4 +54,5 @@ class Config:
             )
 
         self.output_path = output_path
+        self.font_config = font_config
         self.doc_config = doc_config

--- a/swift_book_pdf/fonts.py
+++ b/swift_book_pdf/fonts.py
@@ -17,7 +17,7 @@ import subprocess
 
 logger = logging.getLogger(__name__)
 
-SANS_FONT_LIST = [
+MAIN_FONT_LIST = [
     "Helvetica Neue",
     "Helvetica",
     "SF Pro",
@@ -73,7 +73,7 @@ def find_font(font_list: list[str], available_fonts: str):
 class FontConfig:
     def __init__(
         self,
-        sans_font_list: list[str] = SANS_FONT_LIST,
+        main_font_list: list[str] = MAIN_FONT_LIST,
         mono_font_list: list[str] = MONO_FONT_LIST,
         emoji_font_list: list[str] = EMOJI_FONT_LIST,
         unicode_font_list: list[str] = UNICODE_FONT_LIST,
@@ -85,12 +85,12 @@ class FontConfig:
         logger.debug(f"Available fonts:\n{result.stdout}")
         available_fonts = result.stdout.lower()
 
-        sans_font = find_font(sans_font_list, available_fonts)
-        if not sans_font:
+        main_font = find_font(main_font_list, available_fonts)
+        if not main_font:
             raise ValueError(
-                f"Couldn't find any of the following fonts for sans text: {', '.join(sans_font_list)}. Install one of these fonts to continue. See: {FONT_TROUBLESHOOTING_URL}"
+                f"Couldn't find any of the following fonts for the main text: {', '.join(main_font_list)}. Install one of these fonts to continue. See: {FONT_TROUBLESHOOTING_URL}"
             )
-        self.sans_font = sans_font
+        self.main_font = main_font
 
         mono_font = find_font(mono_font_list, available_fonts)
         if not mono_font:
@@ -121,7 +121,7 @@ class FontConfig:
         self.header_footer_font = header_footer_font
 
         logger.debug("Font configuration:")
-        logger.debug(f"SANS: {self.sans_font}")
+        logger.debug(f"MAIN: {self.main_font}")
         logger.debug(f"MONO: {self.mono_font}")
         logger.debug(f"EMOJI: {self.emoji_font}")
         logger.debug(f"UNICODE: {self.unicode_font}")

--- a/swift_book_pdf/fonts.py
+++ b/swift_book_pdf/fonts.py
@@ -17,58 +17,112 @@ import subprocess
 
 logger = logging.getLogger(__name__)
 
-SANS_FONT = "Helvetica Neue"
-SANS_FONT_BOLD = "Helvetica Neue Bold"
-MONO_FONT = "Menlo"
-EMOJI_FONT = "Apple Color Emoji"
-UNICODE_FONT = "Arial Unicode MS"
-HEADER_FOOTER_FONT = "SF Compact Display"
+SANS_FONT_LIST = [
+    "Helvetica Neue",
+    "Helvetica",
+    "SF Pro",
+    "Arial",
+    "Segoe UI",
+    "Liberation Sans",
+    "DejaVu Sans",
+]
+MONO_FONT_LIST = [
+    "Menlo",
+    "SF Mono",
+    "Courier",
+    "Monaco",
+    "Consolas",
+    "Courier New",
+    "DejaVu Sans Mono",
+    "Ubuntu Mono",
+]
+EMOJI_FONT_LIST = ["Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji"]
+UNICODE_FONT_LIST = [
+    "Arial Unicode MS",
+    "Noto Sans CJK",
+    "Noto Serif CJK",
+]
+HEADER_FOOTER_FONT_LIST = [
+    "SF Compact Display",
+    "SF Pro Display",
+    "SF Compact",
+    "SF Pro",
+    "Helvetica Neue",
+    "Helvetica",
+    "Arial",
+    "Segoe UI",
+    "Liberation Sans",
+    "DejaVu Sans",
+]
 FONT_TROUBLESHOOTING_URL = (
     "https://github.com/ekassos/swift-book-pdf/wiki/Troubleshooting"
 )
 
 
+def find_font(font_list: list[str], available_fonts: str):
+    """Return the first font from font_list that's available, or None otherwise."""
+    for font in font_list:
+        if font.lower() in available_fonts:
+            logger.debug(f'Font "{font}" is accessible by LuaTeX.')
+            return font
+        else:
+            logger.debug(f'Font "{font}" is not accessible by LuaTeX.')
+    return None
+
+
 class FontConfig:
     def __init__(
         self,
-        sans_font: str = SANS_FONT,
-        sans_font_bold: str = SANS_FONT_BOLD,
-        mono_font: str = MONO_FONT,
-        emoji_font: str = EMOJI_FONT,
-        unicode_font: str = UNICODE_FONT,
-        header_footer_font: str = HEADER_FOOTER_FONT,
+        sans_font_list: list[str] = SANS_FONT_LIST,
+        mono_font_list: list[str] = MONO_FONT_LIST,
+        emoji_font_list: list[str] = EMOJI_FONT_LIST,
+        unicode_font_list: list[str] = UNICODE_FONT_LIST,
+        header_footer_font_list: list[str] = HEADER_FOOTER_FONT_LIST,
     ):
+        result = subprocess.run(
+            ["luaotfload-tool", "--list=*"], capture_output=True, text=True
+        )
+        logger.debug(f"Available fonts:\n{result.stdout}")
+        available_fonts = result.stdout.lower()
+
+        sans_font = find_font(sans_font_list, available_fonts)
+        if not sans_font:
+            raise ValueError(
+                f"Couldn't find any of the following fonts for sans text: {', '.join(sans_font_list)}. Install one of these fonts to continue. See: {FONT_TROUBLESHOOTING_URL}"
+            )
         self.sans_font = sans_font
-        self.sans_font_bold = sans_font_bold
+
+        mono_font = find_font(mono_font_list, available_fonts)
+        if not mono_font:
+            raise ValueError(
+                f"Couldn't find any of the following fonts for monospace text: {', '.join(mono_font_list)}. Install one of these fonts to continue. See: {FONT_TROUBLESHOOTING_URL}"
+            )
         self.mono_font = mono_font
+
+        emoji_font = find_font(emoji_font_list, available_fonts)
+        if not emoji_font:
+            raise ValueError(
+                f"Couldn't find any of the following fonts for emojis: {', '.join(emoji_font_list)}. Install one of these fonts to continue. See: {FONT_TROUBLESHOOTING_URL}"
+            )
         self.emoji_font = emoji_font
+
+        unicode_font = find_font(unicode_font_list, available_fonts)
+        if not unicode_font:
+            raise ValueError(
+                f"Couldn't find any of the following fonts for unicode text: {', '.join(unicode_font_list)}. Install one of these fonts to continue. See: {FONT_TROUBLESHOOTING_URL}"
+            )
         self.unicode_font = unicode_font
+
+        header_footer_font = find_font(header_footer_font_list, available_fonts)
+        if not header_footer_font:
+            raise ValueError(
+                f"Couldn't find any of the following fonts for header/footer text: {', '.join(header_footer_font_list)}. Install one of these fonts to continue. See: {FONT_TROUBLESHOOTING_URL}"
+            )
         self.header_footer_font = header_footer_font
 
-    def check_font_availability(self) -> None:
-        fonts = [
-            self.sans_font,
-            self.sans_font_bold,
-            self.mono_font,
-            self.emoji_font,
-            self.unicode_font,
-            self.header_footer_font,
-        ]
-        try:
-            result = subprocess.run(
-                ["luaotfload-tool", "--list=*"], capture_output=True, text=True
-            )
-            logger.debug(f"Available fonts:\n{result.stdout}")
-            available_fonts = result.stdout.lower()
-            for font in fonts:
-                if font.lower() not in available_fonts:
-                    logger.debug(f'Font "{font}" is not accessible by LuaTeX.')
-                    raise ValueError(
-                        f'Can\'t build The Swift Programming Language book: Font "{font}" is not accessible by LuaTeX. See: {FONT_TROUBLESHOOTING_URL}'
-                    )
-                else:
-                    logger.debug(f'Font "{font}" is accessible by LuaTeX.')
-        except FileNotFoundError:
-            raise ValueError(
-                "Can't build The Swift Programming Language book: luaotfload-tool not found. Ensure LuaTeX is installed."
-            )
+        logger.debug("Font configuration:")
+        logger.debug(f"SANS: {self.sans_font}")
+        logger.debug(f"MONO: {self.mono_font}")
+        logger.debug(f"EMOJI: {self.emoji_font}")
+        logger.debug(f"UNICODE: {self.unicode_font}")
+        logger.debug(f"HEADER/FOOTER: {self.header_footer_font}")

--- a/swift_book_pdf/fonts.py
+++ b/swift_book_pdf/fonts.py
@@ -79,11 +79,16 @@ class FontConfig:
         unicode_font_list: list[str] = UNICODE_FONT_LIST,
         header_footer_font_list: list[str] = HEADER_FOOTER_FONT_LIST,
     ):
-        result = subprocess.run(
-            ["luaotfload-tool", "--list=*"], capture_output=True, text=True
-        )
-        logger.debug(f"Available fonts:\n{result.stdout}")
-        available_fonts = result.stdout.lower()
+        try:
+            result = subprocess.run(
+                ["luaotfload-tool", "--list=*"], capture_output=True, text=True
+            )
+            logger.debug(f"Available fonts:\n{result.stdout}")
+            available_fonts = result.stdout.lower()
+        except FileNotFoundError:
+            raise ValueError(
+                "Can't build The Swift Programming Language book: luaotfload-tool not found. Ensure LuaTeX is installed."
+            )
 
         main_font = find_font(main_font_list, available_fonts)
         if not main_font:

--- a/swift_book_pdf/latex.py
+++ b/swift_book_pdf/latex.py
@@ -61,7 +61,11 @@ class LaTeXConverter:
         latex_lines.append("{\\BodyStyle\n")
         blocks = parse_blocks(file_content)
         body_latex = convert_blocks_to_latex(
-            blocks, file_name, self.config.assets_dir, self.config.doc_config.mode
+            blocks,
+            file_name,
+            self.config.assets_dir,
+            self.config.doc_config.mode,
+            self.config.font_config.mono_font,
         )
         latex_lines.extend(body_latex)
         latex_lines.append("}\n\\newpage\n")

--- a/swift_book_pdf/latex.py
+++ b/swift_book_pdf/latex.py
@@ -65,7 +65,7 @@ class LaTeXConverter:
             file_name,
             self.config.assets_dir,
             self.config.doc_config.mode,
-            self.config.font_config.mono_font,
+            self.config.font_config.main_font,
         )
         latex_lines.extend(body_latex)
         latex_lines.append("}\n\\newpage\n")

--- a/swift_book_pdf/latex_helpers.py
+++ b/swift_book_pdf/latex_helpers.py
@@ -458,7 +458,7 @@ def convert_blocks_to_latex(
     file_name: str,
     assets_dir: str,
     mode: RenderingMode,
-    sans_font: str,
+    main_font: str,
 ) -> list[str]:
     """
     Convert parsed blocks into corresponding LaTeX lines.
@@ -467,7 +467,7 @@ def convert_blocks_to_latex(
     :param file_name: The name of the file being converted
     :param assets_dir: The directory containing the images
     :param mode: The rendering mode
-    :param sans_font: The font to be used for sans-serif text
+    :param main_font: The font to be used for the main text
     :return: A list of LaTeX lines
     """
     output: list[str] = []
@@ -588,7 +588,7 @@ def convert_blocks_to_latex(
         elif isinstance(block, TableBlock):
             output.append(
                 "\\begin{table}[H]\n\\centering\n\\setlength{\\tymin}{1in}\\arrayrulecolor{heroGray}\n\\renewcommand{\\arraystretch}{1.5}\n\\fontspec{"
-                + sans_font
+                + main_font
                 + "}\\fontsize{9pt}{1.15\\baselineskip}\\selectfont\\setlength{\\parskip}{0.09in}\\raggedright"
             )
             header_row = block.rows[0]

--- a/swift_book_pdf/latex_helpers.py
+++ b/swift_book_pdf/latex_helpers.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import os
 import re
 import struct
@@ -33,6 +34,8 @@ from swift_book_pdf.schema import (
     TermListBlock,
     UnorderedListBlock,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def generate_chapter_title(lines: list[str], file_name: str) -> tuple[str, list[str]]:
@@ -454,7 +457,11 @@ def convert_nested_block(block: Block, mode: RenderingMode) -> str:
 
 
 def convert_blocks_to_latex(
-    blocks: list[Block], file_name: str, assets_dir: str, mode: RenderingMode
+    blocks: list[Block],
+    file_name: str,
+    assets_dir: str,
+    mode: RenderingMode,
+    sans_font: str,
 ) -> list[str]:
     """
     Convert parsed blocks into corresponding LaTeX lines.
@@ -463,6 +470,7 @@ def convert_blocks_to_latex(
     :param file_name: The name of the file being converted
     :param assets_dir: The directory containing the images
     :param mode: The rendering mode
+    :param sans_font: The font to be used for sans-serif text
     :return: A list of LaTeX lines
     """
     output: list[str] = []
@@ -582,7 +590,9 @@ def convert_blocks_to_latex(
             output.append(f"\\ParagraphStyle{{{para_conv}}}\n")
         elif isinstance(block, TableBlock):
             output.append(
-                "\\begin{table}[H]\n\\centering\n\\setlength{\\tymin}{1in}\\arrayrulecolor{heroGray}\n\\renewcommand{\\arraystretch}{1.5}\n\\fontspec{Helvetica Neue}\\fontsize{9pt}{1.15\\baselineskip}\\selectfont\\setlength{\\parskip}{0.09in}\\raggedright"
+                "\\begin{table}[H]\n\\centering\n\\setlength{\\tymin}{1in}\\arrayrulecolor{heroGray}\n\\renewcommand{\\arraystretch}{1.5}\n\\fontspec{"
+                + sans_font
+                + "}\\fontsize{9pt}{1.15\\baselineskip}\\selectfont\\setlength{\\parskip}{0.09in}\\raggedright"
             )
             header_row = block.rows[0]
             output.append(

--- a/swift_book_pdf/latex_helpers.py
+++ b/swift_book_pdf/latex_helpers.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
 import os
 import re
 import struct
@@ -34,8 +33,6 @@ from swift_book_pdf.schema import (
     TermListBlock,
     UnorderedListBlock,
 )
-
-logger = logging.getLogger(__name__)
 
 
 def generate_chapter_title(lines: list[str], file_name: str) -> tuple[str, list[str]]:

--- a/swift_book_pdf/preamble.py
+++ b/swift_book_pdf/preamble.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from swift_book_pdf.doc import DocConfig
+from swift_book_pdf.config import Config
 from .schema import PaperSize, RenderingMode
 from string import Template
 
@@ -35,10 +35,15 @@ def get_geometry_opts(paper_size: PaperSize) -> str:
     }.get(paper_size, "letterpaper,inner=1.9in")
 
 
-def generate_preamble(doc_config: DocConfig) -> str:
+def generate_preamble(config: Config) -> str:
     return PREAMBLE.substitute(
-        color=get_link_color(doc_config.mode),
-        geometry_opts=get_geometry_opts(doc_config.paper_size),
+        color=get_link_color(config.doc_config.mode),
+        geometry_opts=get_geometry_opts(config.doc_config.paper_size),
+        sans_font=config.font_config.sans_font,
+        mono_font=config.font_config.mono_font,
+        emoji_font=config.font_config.emoji_font,
+        unicode_font=config.font_config.unicode_font,
+        header_footer_font=config.font_config.header_footer_font,
     )
 
 
@@ -83,10 +88,10 @@ PREAMBLE = Template(r"""
 \setlength\parindent{0pt}
 \setcounter{secnumdepth}{4}
 
-\renewcommand{\footnotesize}{\fontspec{Menlo}\fontsize{8pt}{8pt}\selectfont}
+\renewcommand{\footnotesize}{\fontspec{$mono_font}\fontsize{8pt}{8pt}\selectfont}
 \setlength{\footnotesep}{9pt}
 \makeatletter
-\renewcommand{\@makefnmark}{\fontspec{Helvetica Neue}\selectfont\textsuperscript\@thefnmark}
+\renewcommand{\@makefnmark}{\fontspec{$sans_font}\selectfont\textsuperscript\@thefnmark}
 \renewcommand{\@makefntext}[1]{%
   \@hangfrom{\hbox{\@makefnmark\ }}#1%
 }
@@ -94,15 +99,15 @@ PREAMBLE = Template(r"""
 \renewcommand{\thempfootnote}{\arabic{mpfootnote}}
 
 \newcommand{\TitleStyle}{%
-  \fontspec{Helvetica Neue}\fontsize{22pt}{1.2\baselineskip}\selectfont
+  \fontspec{$sans_font}\fontsize{22pt}{1.2\baselineskip}\selectfont
 }
 
 \newcommand{\SubtitleStyle}{%
-\global\precededbyboxfalse\fontspec{Helvetica Neue}\fontsize{11.07pt}{1.2\baselineskip}\selectfont
+\global\precededbyboxfalse\fontspec{$sans_font}\fontsize{11.07pt}{1.2\baselineskip}\selectfont
 }
 
 \newcommand{\BodyStyle}{%
-\fontspec{Helvetica Neue}\fontsize{9pt}{1.15\baselineskip}\selectfont\setlength{\parskip}{0.09in}\raggedright
+\fontspec{$sans_font}\fontsize{9pt}{1.15\baselineskip}\selectfont\setlength{\parskip}{0.09in}\raggedright
 }
 
 \newcommand{\ParagraphStyle}[1]{%
@@ -124,7 +129,7 @@ PREAMBLE = Template(r"""
 \def\section{\@startsection{section}{1}{0pt}%
    {0.4in}
    {0.1in}
-   {\fontspec{Helvetica Neue}\fontsize{22pt}{1.5\baselineskip}\selectfont\global\AtPageTopfalse}}
+   {\fontspec{$sans_font}\fontsize{22pt}{1.5\baselineskip}\selectfont\global\AtPageTopfalse}}
 \makeatother
 
 \newcommand{\TitleSection}[2]{%
@@ -137,7 +142,7 @@ PREAMBLE = Template(r"""
 \def\subsection{\@startsection{subsection}{2}{0pt}%
    {\ifprecededbyparagraph 0.44in \else 0.41in \fi}
    {0.16in}
-   {\fontspec{Helvetica Neue}\fontsize{16.88pt}{1.5\baselineskip}\selectfont\global\precededbysectiontrue\global\precededbyparagraphfalse\global\precededbyboxfalse\global\precededbynotefalse\global\AtPageTopfalse}}
+   {\fontspec{$sans_font}\fontsize{16.88pt}{1.5\baselineskip}\selectfont\global\precededbysectiontrue\global\precededbyparagraphfalse\global\precededbyboxfalse\global\precededbynotefalse\global\AtPageTopfalse}}
 \makeatother
 
 \newcommand{\SectionHeader}[2]{%
@@ -161,7 +166,7 @@ PREAMBLE = Template(r"""
 \def\subsubsection{\@startsection{subsubsection}{3}{0pt}%
    {\ifAtPageTop \ifintoc 0in \else \ifprecededbyparagraph 0.37in \else 0.35in \fi \fi \else \ifprecededbyparagraph 0.37in \else 0.35in \fi \fi}
    {0.16in}
-   {\fontspec{Helvetica Neue}\fontsize{14.77pt}{1.5\baselineskip}\selectfont\global\precededbysectiontrue\global\precededbyparagraphfalse\global\precededbyboxfalse\global\precededbynotefalse\global\AtPageTopfalse}}
+   {\fontspec{$sans_font}\fontsize{14.77pt}{1.5\baselineskip}\selectfont\global\precededbysectiontrue\global\precededbyparagraphfalse\global\precededbyboxfalse\global\precededbynotefalse\global\AtPageTopfalse}}
 \makeatother
 
 \newcommand{\SubsectionHeader}[2]{%
@@ -194,7 +199,7 @@ PREAMBLE = Template(r"""
 \def\paragraph{\@startsection{paragraph}{4}{0pt}%
    {\ifprecededbyparagraph 0.34in \else 0.32in \fi}
    {0.16in}
-   {\fontspec{Helvetica Neue Bold}\fontsize{12.66}{1.5\baselineskip}\selectfont\global\precededbysectiontrue\global\precededbyparagraphfalse\global\precededbyboxfalse\global\precededbynotefalse\global\AtPageTopfalse}}
+   {\bfseries\fontspec{$sans_font}\fontsize{12.66}{1.5\baselineskip}\selectfont\global\precededbysectiontrue\global\precededbyparagraphfalse\global\precededbyboxfalse\global\precededbynotefalse\global\AtPageTopfalse}}
 \makeatother
 
 \newcommand{\SubsubsectionHeader}[2]{%
@@ -207,14 +212,14 @@ PREAMBLE = Template(r"""
 }
 
 \newcommand{\CodeStyle}{%
-  \fontspec{Menlo}\fontsize{9pt}{1.1\baselineskip}\selectfont
+  \fontspec{$mono_font}\fontsize{9pt}{1.1\baselineskip}\selectfont
   \setlength{\parskip}{7pt}\raggedright
 }
-\setmonofont{Menlo}[Scale=1]
+\setmonofont{$mono_font}[Scale=1]
 
 % Define custom emoji style for code
-\newfontfamily\emoji{Apple Color Emoji}[Renderer=Harfbuzz]
-\newfontfamily\unicodeFont{Arial Unicode MS}[Renderer=Harfbuzz]
+\newfontfamily\emoji{$emoji_font}[Renderer=Harfbuzz]
+\newfontfamily\unicodeFont{$unicode_font}[Renderer=Harfbuzz]
 \newcommand{\loweremoji}[1]{\raisebox{-0.2ex}{#1}}
 \newcommand{\textNonLatin}[1]{\unicodeFont{#1}}
 
@@ -360,7 +365,7 @@ PREAMBLE = Template(r"""
   };
 
   \node[anchor=east,white] at ([yshift=-0.70in,xshift=-0.95in]current page.north east) {
-    \scalebox{1.10}[1]{\fontspec{SF Compact Display}[LetterSpace=-3.5] \fontsize{13pt}{0pt}\selectfont \customheader}
+    \scalebox{1.10}[1]{\fontspec{$header_footer_font}[LetterSpace=-3.5] \fontsize{13pt}{0pt}\selectfont \customheader}
   };
 \end{tikzpicture}%
 }
@@ -376,7 +381,7 @@ PREAMBLE = Template(r"""
 };
 
 \node[anchor=west,white] at ([yshift=-0.71in,xshift=0.95in]current page.north west) {
-  \scalebox{1.10}[1]{\fontspec{SF Compact Display}[LetterSpace=-3.5] \fontsize{13pt}{0pt}\selectfont The Swift Programming Language}
+  \scalebox{1.10}[1]{\fontspec{$header_footer_font}[LetterSpace=-3.5] \fontsize{13pt}{0pt}\selectfont The Swift Programming Language}
 };
 \end{tikzpicture}%
 }
@@ -391,7 +396,7 @@ PREAMBLE = Template(r"""
 };
 
 \node[anchor=east,white] at ([yshift=0.7in,xshift=-1in]current page.south east) {
-  \fontspec{SF Compact Display} \fontsize{13pt}{0pt}\selectfont \thepage
+  \fontspec{$header_footer_font} \fontsize{13pt}{0pt}\selectfont \thepage
 };
 \end{tikzpicture}%
 }
@@ -406,7 +411,7 @@ PREAMBLE = Template(r"""
 };
 
 \node[anchor=west,white] at ([yshift=0.7in,xshift=1in]current page.south west) {
-  \fontspec{SF Compact Display} \fontsize{13pt}{0pt}\selectfont \thepage
+  \fontspec{$header_footer_font} \fontsize{13pt}{0pt}\selectfont \thepage
 };
 \end{tikzpicture}%
 }
@@ -423,7 +428,7 @@ PREAMBLE = Template(r"""
   };
 
   \node[anchor=east,white] at ([yshift=0.7in,xshift=-1in]current page.south east) {
-    \fontspec{SF Compact Display} \fontsize{13pt}{0pt}\selectfont \thepage
+    \fontspec{$header_footer_font} \fontsize{13pt}{0pt}\selectfont \thepage
   };
   \end{tikzpicture}%
   }
@@ -438,7 +443,7 @@ PREAMBLE = Template(r"""
   };
 
   \node[anchor=west,white] at ([yshift=0.7in,xshift=1in]current page.south west) {
-    \fontspec{SF Compact Display} \fontsize{13pt}{0pt}\selectfont \thepage
+    \fontspec{$header_footer_font} \fontsize{13pt}{0pt}\selectfont \thepage
   };
   \end{tikzpicture}%
   }

--- a/swift_book_pdf/preamble.py
+++ b/swift_book_pdf/preamble.py
@@ -39,7 +39,7 @@ def generate_preamble(config: Config) -> str:
     return PREAMBLE.substitute(
         color=get_link_color(config.doc_config.mode),
         geometry_opts=get_geometry_opts(config.doc_config.paper_size),
-        sans_font=config.font_config.sans_font,
+        main_font=config.font_config.main_font,
         mono_font=config.font_config.mono_font,
         emoji_font=config.font_config.emoji_font,
         unicode_font=config.font_config.unicode_font,
@@ -91,7 +91,7 @@ PREAMBLE = Template(r"""
 \renewcommand{\footnotesize}{\fontspec{$mono_font}\fontsize{8pt}{8pt}\selectfont}
 \setlength{\footnotesep}{9pt}
 \makeatletter
-\renewcommand{\@makefnmark}{\fontspec{$sans_font}\selectfont\textsuperscript\@thefnmark}
+\renewcommand{\@makefnmark}{\fontspec{$main_font}\selectfont\textsuperscript\@thefnmark}
 \renewcommand{\@makefntext}[1]{%
   \@hangfrom{\hbox{\@makefnmark\ }}#1%
 }
@@ -99,15 +99,15 @@ PREAMBLE = Template(r"""
 \renewcommand{\thempfootnote}{\arabic{mpfootnote}}
 
 \newcommand{\TitleStyle}{%
-  \fontspec{$sans_font}\fontsize{22pt}{1.2\baselineskip}\selectfont
+  \fontspec{$main_font}\fontsize{22pt}{1.2\baselineskip}\selectfont
 }
 
 \newcommand{\SubtitleStyle}{%
-\global\precededbyboxfalse\fontspec{$sans_font}\fontsize{11.07pt}{1.2\baselineskip}\selectfont
+\global\precededbyboxfalse\fontspec{$main_font}\fontsize{11.07pt}{1.2\baselineskip}\selectfont
 }
 
 \newcommand{\BodyStyle}{%
-\fontspec{$sans_font}\fontsize{9pt}{1.15\baselineskip}\selectfont\setlength{\parskip}{0.09in}\raggedright
+\fontspec{$main_font}\fontsize{9pt}{1.15\baselineskip}\selectfont\setlength{\parskip}{0.09in}\raggedright
 }
 
 \newcommand{\ParagraphStyle}[1]{%
@@ -129,7 +129,7 @@ PREAMBLE = Template(r"""
 \def\section{\@startsection{section}{1}{0pt}%
    {0.4in}
    {0.1in}
-   {\fontspec{$sans_font}\fontsize{22pt}{1.5\baselineskip}\selectfont\global\AtPageTopfalse}}
+   {\fontspec{$main_font}\fontsize{22pt}{1.5\baselineskip}\selectfont\global\AtPageTopfalse}}
 \makeatother
 
 \newcommand{\TitleSection}[2]{%
@@ -142,7 +142,7 @@ PREAMBLE = Template(r"""
 \def\subsection{\@startsection{subsection}{2}{0pt}%
    {\ifprecededbyparagraph 0.44in \else 0.41in \fi}
    {0.16in}
-   {\fontspec{$sans_font}\fontsize{16.88pt}{1.5\baselineskip}\selectfont\global\precededbysectiontrue\global\precededbyparagraphfalse\global\precededbyboxfalse\global\precededbynotefalse\global\AtPageTopfalse}}
+   {\fontspec{$main_font}\fontsize{16.88pt}{1.5\baselineskip}\selectfont\global\precededbysectiontrue\global\precededbyparagraphfalse\global\precededbyboxfalse\global\precededbynotefalse\global\AtPageTopfalse}}
 \makeatother
 
 \newcommand{\SectionHeader}[2]{%
@@ -166,7 +166,7 @@ PREAMBLE = Template(r"""
 \def\subsubsection{\@startsection{subsubsection}{3}{0pt}%
    {\ifAtPageTop \ifintoc 0in \else \ifprecededbyparagraph 0.37in \else 0.35in \fi \fi \else \ifprecededbyparagraph 0.37in \else 0.35in \fi \fi}
    {0.16in}
-   {\fontspec{$sans_font}\fontsize{14.77pt}{1.5\baselineskip}\selectfont\global\precededbysectiontrue\global\precededbyparagraphfalse\global\precededbyboxfalse\global\precededbynotefalse\global\AtPageTopfalse}}
+   {\fontspec{$main_font}\fontsize{14.77pt}{1.5\baselineskip}\selectfont\global\precededbysectiontrue\global\precededbyparagraphfalse\global\precededbyboxfalse\global\precededbynotefalse\global\AtPageTopfalse}}
 \makeatother
 
 \newcommand{\SubsectionHeader}[2]{%
@@ -199,7 +199,7 @@ PREAMBLE = Template(r"""
 \def\paragraph{\@startsection{paragraph}{4}{0pt}%
    {\ifprecededbyparagraph 0.34in \else 0.32in \fi}
    {0.16in}
-   {\bfseries\fontspec{$sans_font}\fontsize{12.66}{1.5\baselineskip}\selectfont\global\precededbysectiontrue\global\precededbyparagraphfalse\global\precededbyboxfalse\global\precededbynotefalse\global\AtPageTopfalse}}
+   {\bfseries\fontspec{$main_font}\fontsize{12.66}{1.5\baselineskip}\selectfont\global\precededbysectiontrue\global\precededbyparagraphfalse\global\precededbyboxfalse\global\precededbynotefalse\global\AtPageTopfalse}}
 \makeatother
 
 \newcommand{\SubsubsectionHeader}[2]{%


### PR DESCRIPTION
The current font requirements to typeset TSPL are quite macOS-centric. swift-book-pdf will now typeset TSPL in any system where LuaTeX has access to at least one font in each of the following font categories:

* **Main Font:** Helvetica Neue, Helvetica, SF Pro, Arial, Segoe UI, Liberation Sans, DejaVu Sans
* **Unicode Font:[^1]** Arial Unicode MS, Noto Sans CJK, Noto Serif CJK
* **Mono Font:** Menlo, SF Mono, Courier, Monaco, Consolas, Courier New, DejaVu Sans Mono, Ubuntu Mono
* **Emoji Font:** Apple Color Emoji, Segoe UI Emoji, Noto Color Emoji
* **Header & Footer Font:** SF Compact Display, SF Pro Display, SF Compact, SF Pro, Helvetica Neue, Helvetica, SF Pro, Arial, Segoe UI, Liberation Sans, DejaVu Sans

This change should make it easier for Windows and Linux users to generate a PDF for The Swift Programming Language book.

[^1]: Adds support for the following characters currently included in TSPL, which are not supported by the Main Font: 你, 好, 世, 界, 한, ᄒ, ᅡ, ᆫ, 안, 녕, 三, 一, 二, 三, 四, 三,