### PR TITLE
feat: Add option to set custom fonts

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-font-bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/01-font-bug-report.yaml
@@ -1,0 +1,51 @@
+name: Font Issue Report
+description: File a font bug report if you're seeing something that doesn't look right.
+title: "[Bug]: "
+labels: ["bug", "triage", "fonts"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+
+        Please complete all questions and **provide the log output**. This will help us to reproduce the issue and get it fixed as quickly as possible.
+  - type: markdown
+    attributes:
+      value: "## Basic Information"
+  - type: input
+    id: font
+    attributes:
+      label: Font name
+      description: |
+        Please provide the name of the font you are using. The error message should contain the name of the font.
+      placeholder: "Menlo"
+  - type: input
+    id: offending-character
+    attributes:
+      label: Character causing the issue
+      description: |
+        Please provide the character that is causing the issue with the Unicode code point. The error message should contain the character.
+      placeholder: "你 (U+4F60)"
+  - type: markdown
+    attributes:
+      value: "## Log Information"
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant error logs
+      description: |
+        Please copy and paste the relevant error logs. It should look something like this:
+        
+        ```
+        [ERROR]: Couldn't build The Swift Programming Language book: Menlo does not support character 你 (U+4F60).    
+        If you are using a custom font, please ensure that it supports the character set you are trying to use.
+        Otherwise, see https://github.com/ekassos/swift-book-pdf/wiki/Troubleshooting for more information.
+        
+        Your font configuration:
+        Main font: Helvetica Neue (default font)
+        Monospace font: Menlo (default font)
+        Emoji font: Apple Color Emoji (default font)
+        Unicode font: Arial Unicode MS (default font)
+        Header/Footer font: SF Compact Display (default font)
+        ```
+      render: shell

--- a/.github/ISSUE_TEMPLATE/01-font-bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/01-font-bug-report.yaml
@@ -17,7 +17,7 @@ body:
     attributes:
       label: Confirmation
       options:
-        - label: The issue is caused by one of the default fonts.
+        - label: The issue is caused when using a default font.
           required: true
   - type: input
     id: font

--- a/.github/ISSUE_TEMPLATE/01-font-bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/01-font-bug-report.yaml
@@ -12,35 +12,49 @@ body:
   - type: markdown
     attributes:
       value: "## Basic Information"
+  - type: checkboxes
+    id: confirmation
+    attributes:
+      label: Confirmation
+      options:
+        - label: The issue is caused by one of the default fonts.
+          required: true
   - type: input
     id: font
     attributes:
       label: Font name
       description: |
-        Please provide the name of the font you are using. The error message should contain the name of the font.
+        Provide the name of the font you are using. The error message should contain the name of the font.
       placeholder: "Menlo"
   - type: input
     id: offending-character
     attributes:
       label: Character causing the issue
       description: |
-        Please provide the character that is causing the issue with the Unicode code point. The error message should contain the character.
+        Provide the character that is causing the issue with the Unicode code point. The error message should contain the character.
       placeholder: "你 (U+4F60)"
   - type: markdown
     attributes:
-      value: "## Log Information"
+      value: "## Technical Information"
+  - type: input
+    id: version
+    attributes:
+      label: swift-book-pdf version
+      description: |
+        Provide the version of swift-book-pdf you are using. You can find this by running `swift-book-pdf --version` in your terminal.
+      placeholder: "1.0.0"
   - type: textarea
     id: logs
     attributes:
       label: Relevant error logs
       description: |
         Please copy and paste the relevant error logs. It should look something like this:
-        
+
         ```
-        [ERROR]: Couldn't build The Swift Programming Language book: Menlo does not support character 你 (U+4F60).    
+        [ERROR]: Couldn't build The Swift Programming Language book: Menlo does not support character 你 (U+4F60).
         If you are using a custom font, please ensure that it supports the character set you are trying to use.
         Otherwise, see https://github.com/ekassos/swift-book-pdf/wiki/Troubleshooting for more information.
-        
+
         Your font configuration:
         Main font: Helvetica Neue (default font)
         Monospace font: Menlo (default font)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 ### Added
 
-- Added more default font options, organized in five font categories. swift-book-pdf will now typeset TSPL in any system where LuaTeX has access to at least one font in each font category.
+- Add more default font options, organized in five font categories. swift-book-pdf will now typeset TSPL in any system where LuaTeX has access to at least one font in each font category.
+- Add option to use custom fonts.
+- Add error reporting when a font (custom or default) does not support a typeset character based on the assigned font category.
+- Add `--version` CLI option.
+- Add Github issue template for font issue reporting.
 
 ## [1.1.0] - 2025-03-13
 

--- a/swift_book_pdf/cli.py
+++ b/swift_book_pdf/cli.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Optional
 import click
 import logging
 
@@ -61,14 +62,61 @@ def cli() -> None:
     help="Number of typeset passes to use",
     show_default="4",
 )
+@click.option(
+    "--main",
+    type=str,
+    default=None,
+    help="Font for the main text",
+)
+@click.option(
+    "--mono",
+    type=str,
+    default=None,
+    help="Font for code blocks",
+)
+@click.option(
+    "--unicode",
+    type=str,
+    default=None,
+    help="Font for characters not supported by the main font",
+)
+@click.option(
+    "--emoji",
+    type=str,
+    default=None,
+    help="Font for emoji",
+)
+@click.option(
+    "--header-footer",
+    type=str,
+    default=None,
+    help="Font for text in the header and footer",
+)
 @click.option("--verbose", is_flag=True)
-def run(output_path: str, mode: str, verbose: bool, typesets: int, paper: str) -> None:
+def run(
+    output_path: str,
+    mode: str,
+    verbose: bool,
+    typesets: int,
+    paper: str,
+    main: Optional[str],
+    mono: Optional[str],
+    unicode: Optional[str],
+    emoji: Optional[str],
+    header_footer: Optional[str],
+) -> None:
     configure_logging(verbose)
     logger = logging.getLogger(__name__)
 
     try:
         output_path = validate_output_path(output_path)
-        font_config = FontConfig()
+        font_config = FontConfig(
+            main_font_custom=main,
+            mono_font_custom=mono,
+            unicode_font_custom=unicode,
+            emoji_font_custom=emoji,
+            header_footer_font_custom=header_footer,
+        )
         doc_config = DocConfig(RenderingMode(mode), PaperSize(paper), typesets)
     except ValueError as e:
         logger.error(str(e))
@@ -76,7 +124,12 @@ def run(output_path: str, mode: str, verbose: bool, typesets: int, paper: str) -
 
     with TemporaryDirectory() as temp:
         config = Config(temp, output_path, font_config, doc_config)
-        Book(config).process()
+        try:
+            Book(config).process()
+        except Exception as e:
+            logger.error(
+                f"Couldn't build The Swift Programming Language book: {e}\n{font_config}"
+            )
 
 
 if __name__ == "__main__":

--- a/swift_book_pdf/cli.py
+++ b/swift_book_pdf/cli.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib
 from typing import Optional
 import click
 import logging
@@ -93,6 +94,7 @@ def cli() -> None:
     help="Font for text in the header and footer",
 )
 @click.option("--verbose", is_flag=True)
+@click.option("--version", is_flag=True)
 def run(
     output_path: str,
     mode: str,
@@ -104,7 +106,13 @@ def run(
     unicode: Optional[str],
     emoji: Optional[str],
     header_footer: Optional[str],
+    version: bool,
 ) -> None:
+    if version:
+        current_version = importlib.metadata.version("swift-book-pdf")
+        click.echo(f"swift-book-pdf {current_version}")
+        return
+
     configure_logging(verbose)
     logger = logging.getLogger(__name__)
 

--- a/swift_book_pdf/fonts.py
+++ b/swift_book_pdf/fonts.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 import logging
+import re
 import subprocess
+from typing import Optional
 
 logger = logging.getLogger(__name__)
 
@@ -73,6 +75,11 @@ def find_font(font_list: list[str], available_fonts: str):
 class FontConfig:
     def __init__(
         self,
+        main_font_custom: Optional[str] = None,
+        mono_font_custom: Optional[str] = None,
+        emoji_font_custom: Optional[str] = None,
+        unicode_font_custom: Optional[str] = None,
+        header_footer_font_custom: Optional[str] = None,
         main_font_list: list[str] = MAIN_FONT_LIST,
         mono_font_list: list[str] = MONO_FONT_LIST,
         emoji_font_list: list[str] = EMOJI_FONT_LIST,
@@ -90,35 +97,75 @@ class FontConfig:
                 "Can't build The Swift Programming Language book: luaotfload-tool not found. Ensure LuaTeX is installed."
             )
 
-        main_font = find_font(main_font_list, available_fonts)
+        if main_font_custom:
+            main_font = find_font([main_font_custom], available_fonts)
+            if not main_font:
+                logging.warning(
+                    f"Custom main font '{main_font_custom}' not found. Using default fonts."
+                )
+                main_font = find_font(main_font_list, available_fonts)
+        else:
+            main_font = find_font(main_font_list, available_fonts)
         if not main_font:
             raise ValueError(
                 f"Couldn't find any of the following fonts for the main text: {', '.join(main_font_list)}. Install one of these fonts to continue. See: {FONT_TROUBLESHOOTING_URL}"
             )
         self.main_font = main_font
 
-        mono_font = find_font(mono_font_list, available_fonts)
+        if mono_font_custom:
+            mono_font = find_font([mono_font_custom], available_fonts)
+            if not mono_font:
+                logging.warning(
+                    f"Custom monospace font '{mono_font_custom}' not found. Using default fonts."
+                )
+                mono_font = find_font(mono_font_list, available_fonts)
+        else:
+            mono_font = find_font(mono_font_list, available_fonts)
         if not mono_font:
             raise ValueError(
                 f"Couldn't find any of the following fonts for monospace text: {', '.join(mono_font_list)}. Install one of these fonts to continue. See: {FONT_TROUBLESHOOTING_URL}"
             )
         self.mono_font = mono_font
 
-        emoji_font = find_font(emoji_font_list, available_fonts)
+        if emoji_font_custom:
+            emoji_font = find_font([emoji_font_custom], available_fonts)
+            if not emoji_font:
+                logging.warning(
+                    f"Custom emoji font '{emoji_font_custom}' not found. Using default fonts."
+                )
+                emoji_font = find_font(emoji_font_list, available_fonts)
+        else:
+            emoji_font = find_font(emoji_font_list, available_fonts)
         if not emoji_font:
             raise ValueError(
                 f"Couldn't find any of the following fonts for emojis: {', '.join(emoji_font_list)}. Install one of these fonts to continue. See: {FONT_TROUBLESHOOTING_URL}"
             )
         self.emoji_font = emoji_font
 
-        unicode_font = find_font(unicode_font_list, available_fonts)
+        if unicode_font_custom:
+            unicode_font = find_font([unicode_font_custom], available_fonts)
+            if not unicode_font:
+                logging.warning(
+                    f"Custom unicode font '{unicode_font_custom}' not found. Using default fonts."
+                )
+                unicode_font = find_font(unicode_font_list, available_fonts)
+        else:
+            unicode_font = find_font(unicode_font_list, available_fonts)
         if not unicode_font:
             raise ValueError(
                 f"Couldn't find any of the following fonts for unicode text: {', '.join(unicode_font_list)}. Install one of these fonts to continue. See: {FONT_TROUBLESHOOTING_URL}"
             )
         self.unicode_font = unicode_font
 
-        header_footer_font = find_font(header_footer_font_list, available_fonts)
+        if header_footer_font_custom:
+            header_footer_font = find_font([header_footer_font_custom], available_fonts)
+            if not header_footer_font:
+                logging.warning(
+                    f"Custom header/footer font '{header_footer_font_custom}' not found. Using default fonts."
+                )
+                header_footer_font = find_font(header_footer_font_list, available_fonts)
+        else:
+            header_footer_font = find_font(header_footer_font_list, available_fonts)
         if not header_footer_font:
             raise ValueError(
                 f"Couldn't find any of the following fonts for header/footer text: {', '.join(header_footer_font_list)}. Install one of these fonts to continue. See: {FONT_TROUBLESHOOTING_URL}"
@@ -131,3 +178,37 @@ class FontConfig:
         logger.debug(f"EMOJI: {self.emoji_font}")
         logger.debug(f"UNICODE: {self.unicode_font}")
         logger.debug(f"HEADER/FOOTER: {self.header_footer_font}")
+
+    def __str__(self):
+        return (
+            "Your font configuration:\n"
+            f"Main font: {self.main_font} ({'default font' if self.main_font in MAIN_FONT_LIST else 'custom font'})\n"
+            f"Monospace font: {self.mono_font} ({'default font' if self.mono_font in MONO_FONT_LIST else 'custom font'})\n"
+            f"Emoji font: {self.emoji_font} ({'default font' if self.emoji_font in EMOJI_FONT_LIST else 'custom font'})\n"
+            f"Unicode font: {self.unicode_font} ({'default font' if self.unicode_font in UNICODE_FONT_LIST else 'custom font'})\n"
+            f"Header/Footer font: {self.header_footer_font} ({'default font' if self.header_footer_font in HEADER_FOOTER_FONT_LIST else 'custom font'})\n"
+        )
+
+
+def check_for_missing_font_logs(log_line: str):
+    """Check for missing font logs in the given log line.
+    If a missing font is detected, raise a ValueError with a message
+    indicating the font name and the character that is missing.
+    Args:
+        log_line (str): The log line to check.
+    Raises:
+        ValueError: If a missing font is detected.
+    """
+    pattern = re.compile(
+        r"Missing character: There is no (?P<char>\S+) "
+        r"\((?P<code>U\+\w+)\) in font name:(?P<font>[^:]+):"
+    )
+
+    match = pattern.search(log_line)
+    if match:
+        missing_char = match.group("char")
+        unicode_code = match.group("code")
+        font_name = match.group("font")
+        raise ValueError(
+            f"{font_name} does not support character {missing_char} ({unicode_code}).\nIf you are using a custom font, please ensure that it supports the character set you are trying to use.\nOtherwise, see {FONT_TROUBLESHOOTING_URL} for more information."
+        )

--- a/swift_book_pdf/fonts.py
+++ b/swift_book_pdf/fonts.py
@@ -100,7 +100,7 @@ class FontConfig:
         if main_font_custom:
             main_font = find_font([main_font_custom], available_fonts)
             if not main_font:
-                logging.warning(
+                logger.warning(
                     f"Custom main font '{main_font_custom}' not found. Using default fonts."
                 )
                 main_font = find_font(main_font_list, available_fonts)
@@ -115,7 +115,7 @@ class FontConfig:
         if mono_font_custom:
             mono_font = find_font([mono_font_custom], available_fonts)
             if not mono_font:
-                logging.warning(
+                logger.warning(
                     f"Custom monospace font '{mono_font_custom}' not found. Using default fonts."
                 )
                 mono_font = find_font(mono_font_list, available_fonts)
@@ -130,7 +130,7 @@ class FontConfig:
         if emoji_font_custom:
             emoji_font = find_font([emoji_font_custom], available_fonts)
             if not emoji_font:
-                logging.warning(
+                logger.warning(
                     f"Custom emoji font '{emoji_font_custom}' not found. Using default fonts."
                 )
                 emoji_font = find_font(emoji_font_list, available_fonts)
@@ -145,7 +145,7 @@ class FontConfig:
         if unicode_font_custom:
             unicode_font = find_font([unicode_font_custom], available_fonts)
             if not unicode_font:
-                logging.warning(
+                logger.warning(
                     f"Custom unicode font '{unicode_font_custom}' not found. Using default fonts."
                 )
                 unicode_font = find_font(unicode_font_list, available_fonts)
@@ -160,7 +160,7 @@ class FontConfig:
         if header_footer_font_custom:
             header_footer_font = find_font([header_footer_font_custom], available_fonts)
             if not header_footer_font:
-                logging.warning(
+                logger.warning(
                     f"Custom header/footer font '{header_footer_font_custom}' not found. Using default fonts."
                 )
                 header_footer_font = find_font(header_footer_font_list, available_fonts)
@@ -201,7 +201,7 @@ def check_for_missing_font_logs(log_line: str):
     """
     pattern = re.compile(
         r"Missing character: There is no (?P<char>\S+) "
-        r"\((?P<code>U\+\w+)\) in font name:(?P<font>[^:]+):"
+        r"\((?P<code>U\+\w+)\) in font name:(?P<font>.+?):"
     )
 
     match = pattern.search(log_line)

--- a/swift_book_pdf/log.py
+++ b/swift_book_pdf/log.py
@@ -17,6 +17,7 @@ import sys
 import textwrap
 
 from subprocess import Popen
+from typing import Callable, Optional
 
 
 def configure_logging(verbose: bool):
@@ -31,7 +32,10 @@ def configure_logging(verbose: bool):
 
 
 def run_process_with_logs(
-    process: Popen[str], MAX_LINES: int = 10, MAX_LINE_LENGTH: int = 80
+    process: Popen[str],
+    MAX_LINES: int = 10,
+    MAX_LINE_LENGTH: int = 80,
+    log_check_func: Optional[Callable] = None,
 ) -> None:
     last_lines = []
     printed_lines = 0
@@ -47,6 +51,10 @@ def run_process_with_logs(
         line = process.stdout.readline()
         if not line:
             break
+
+        # Check if the line contains a specific log message
+        if log_check_func is not None:
+            log_check_func(line)
 
         # Split long lines
         if len(line.rstrip("\n")) > MAX_LINE_LENGTH:

--- a/swift_book_pdf/pdf.py
+++ b/swift_book_pdf/pdf.py
@@ -16,6 +16,7 @@ import os
 import subprocess
 
 from swift_book_pdf.config import Config
+from swift_book_pdf.fonts import check_for_missing_font_logs
 from swift_book_pdf.log import run_process_with_logs
 
 
@@ -47,4 +48,4 @@ class PDFConverter:
             bufsize=1,
         )
 
-        run_process_with_logs(process)
+        run_process_with_logs(process, log_check_func=check_for_missing_font_logs)


### PR DESCRIPTION
- Adds the option to specify custom fonts for each of the five font categories introduced in #12. 
- swift_book_pdf will verify that such fonts are available to LuaTeX before typesetting. 
- An error is raised when a font (custom or default) does not support a typeset character based on the assigned font category. 
- Adds `--version` option and issue template for font issue reporting.