### PR TITLE
feat/ Better Unicode + Emoji character handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Internal
 - Replace `wrap_emoji_string` and `detect_non_latin`/`wrap_non_latin` processing pipelines with `luaotfload` font fallbacks.
 - Add new `override_characters` function for characters requiring special handling before typesetting. Previously handled within `wrap_non_latin`.
+- Remove `emoji` dependency.
 
 ## [1.2.0] - 2025-03-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### Changed
+- When rendering unsupported characters, fall through all available fonts in case the character is supported by one of the other available fonts.
+
+### Internal
+- Replace `wrap_emoji_string` and `detect_non_latin`/`wrap_non_latin` processing pipelines with `luaotfload` font fallbacks.
+- Add new `override_characters` function for characters requiring special handling before typesetting. Previously handled within `wrap_non_latin`.
+
 ## [1.2.0] - 2025-03-15
 
 ### Added

--- a/poetry.lock
+++ b/poetry.lock
@@ -65,21 +65,6 @@ files = [
 ]
 
 [[package]]
-name = "emoji"
-version = "2.14.1"
-description = "Emoji for Python"
-optional = false
-python-versions = ">=3.7"
-groups = ["main"]
-files = [
-    {file = "emoji-2.14.1-py3-none-any.whl", hash = "sha256:35a8a486c1460addb1499e3bf7929d3889b2e2841a57401903699fef595e942b"},
-    {file = "emoji-2.14.1.tar.gz", hash = "sha256:f8c50043d79a2c1410ebfae833ae1868d5941a67a6cd4d18377e2eb0bd79346b"},
-]
-
-[package.extras]
-dev = ["coverage", "pytest (>=7.4.4)"]
-
-[[package]]
 name = "filelock"
 version = "3.17.0"
 description = "A platform independent file lock."
@@ -429,4 +414,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9"
-content-hash = "70553c29e6ffe1e267cee2362400199211fa7763245219ddcc533164cf62eeed"
+content-hash = "d3f3ab344ddb3f657453e03aedff4f9a1bfcf088f70a2f050f2e721600b341fc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 authors = [{ name = "Evangelos Kassos", email = "github@evangeloskassos.com" }]
 keywords = ["swift", "book", "pdf"]
 requires-python = ">=3.9"
-dependencies = ["pygments (>=2.9.0,<3.0.0)", "tqdm (>=4.67.1,<5.0.0)", "emoji (>=2.14.1,<3.0.0)", "pydantic (>=2.10.6,<3.0.0)", "click (>=8.1.8,<9.0.0)"]
+dependencies = ["pygments (>=2.9.0,<3.0.0)", "tqdm (>=4.67.1,<5.0.0)", "pydantic (>=2.10.6,<3.0.0)", "click (>=8.1.8,<9.0.0)"]
 
 [project.urls]
 repository = "https://github.com/ekassos/swift-book-pdf.git"

--- a/swift_book_pdf/latex_helpers.py
+++ b/swift_book_pdf/latex_helpers.py
@@ -112,11 +112,14 @@ def escape_texttt(text: str) -> str:
     return text
 
 
-def override_characters(text: str) -> str:
+def override_characters(text: str, in_code_block: bool = False) -> str:
     """
     Override characters in text that may have special formatting in LaTeX.
     """
     override_set = {"é⃝": "\\textcircled{é}"}
+
+    if in_code_block:
+        override_set = {k: f"|{v}|" for k, v in override_set.items()}
 
     for char, replacement in override_set.items():
         text = text.replace(char, replacement)
@@ -279,7 +282,7 @@ def convert_blocks_to_latex(
                 # Escape % characters
                 line = line.replace("%", "\%")
                 # Escape non-latin and emoji characters
-                output.append(override_characters(line))
+                output.append(override_characters(line, True))
             output.append(r"\end{swiftstyledbox}" + "\n\\end{flushleft}\n")
         elif isinstance(block, UnorderedListBlock):
             output.append(r"\begin{itemize}")
@@ -386,9 +389,9 @@ def convert_blocks_to_latex(
             output.append(f"\\ParagraphStyle{{{para_conv}}}\n")
         elif isinstance(block, TableBlock):
             output.append(
-                "\\begin{table}[H]\n\\centering\n\\setlength{\\tymin}{1in}\\arrayrulecolor{heroGray}\n\\renewcommand{\\arraystretch}{1.5}\n\\fontspec{"
+                "\\begin{table}[H]\n\\centering\n\\setlength{\\tymin}{1in}\\arrayrulecolor{heroGray}\n\\renewcommand{\\arraystretch}{1.5}\n\\mainFontWithFallback{"
                 + main_font
-                + "}[RawFeature={fallback=monoFallback}]\\fontsize{9pt}{1.15\\baselineskip}\\selectfont\\setlength{\\parskip}{0.09in}\\raggedright"
+                + "}\\fontsize{9pt}{1.15\\baselineskip}\\selectfont\\setlength{\\parskip}{0.09in}\\raggedright"
             )
             header_row = block.rows[0]
             output.append(

--- a/swift_book_pdf/preamble.py
+++ b/swift_book_pdf/preamble.py
@@ -129,8 +129,8 @@ PREAMBLE = Template(r"""
   \fontspec{#1}[RawFeature={fallback=monoFallback}]%
 }
 
-\newcommand{\headerFontWithFallback}[1]{%
-  \fontspec{#1}[RawFeature={fallback=headerFallback}]%
+\newcommand{\headerFontWithFallback}[2]{%
+  \fontspec{#1}[RawFeature={fallback=headerFallback},#2]%
 }
 
 \renewcommand{\footnotesize}{\monoFontWithFallback{$mono_font}\fontsize{8pt}{8pt}\selectfont}
@@ -260,7 +260,7 @@ PREAMBLE = Template(r"""
   \monoFontWithFallback{$mono_font}\fontsize{9pt}{1.1\baselineskip}\selectfont
   \setlength{\parskip}{7pt}\raggedright
 }
-\setmonofont{$mono_font}[RawFeature={fallback=monoFallback}]
+\setmonofont{$mono_font}[RawFeature={fallback=monoFallback}, Scale=1]
 
 % Define custom emoji style for code
 \newfontfamily\emoji{$emoji_font}[Renderer=Harfbuzz]
@@ -410,7 +410,7 @@ PREAMBLE = Template(r"""
   };
 
   \node[anchor=east,white] at ([yshift=-0.70in,xshift=-0.95in]current page.north east) {
-    \scalebox{1.10}[1]{\headerFontWithFallback{$header_footer_font}[LetterSpace=-3.5] \fontsize{13pt}{0pt}\selectfont \customheader}
+    \scalebox{1.10}[1]{\headerFontWithFallback{$header_footer_font}{LetterSpace=-3.5} \fontsize{13pt}{0pt}\selectfont \customheader}
   };
 \end{tikzpicture}%
 }
@@ -426,7 +426,7 @@ PREAMBLE = Template(r"""
 };
 
 \node[anchor=west,white] at ([yshift=-0.71in,xshift=0.95in]current page.north west) {
-  \scalebox{1.10}[1]{\headerFontWithFallback{$header_footer_font}[LetterSpace=-3.5] \fontsize{13pt}{0pt}\selectfont The Swift Programming Language}
+  \scalebox{1.10}[1]{\headerFontWithFallback{$header_footer_font}{LetterSpace=-3.5} \fontsize{13pt}{0pt}\selectfont The Swift Programming Language}
 };
 \end{tikzpicture}%
 }
@@ -441,7 +441,7 @@ PREAMBLE = Template(r"""
 };
 
 \node[anchor=east,white] at ([yshift=0.7in,xshift=-1in]current page.south east) {
-  \headerFontWithFallback{$header_footer_font} \fontsize{13pt}{0pt}\selectfont \thepage
+  \headerFontWithFallback{$header_footer_font}{} \fontsize{13pt}{0pt}\selectfont \thepage
 };
 \end{tikzpicture}%
 }
@@ -456,7 +456,7 @@ PREAMBLE = Template(r"""
 };
 
 \node[anchor=west,white] at ([yshift=0.7in,xshift=1in]current page.south west) {
-  \headerFontWithFallback{$header_footer_font} \fontsize{13pt}{0pt}\selectfont \thepage
+  \headerFontWithFallback{$header_footer_font}{} \fontsize{13pt}{0pt}\selectfont \thepage
 };
 \end{tikzpicture}%
 }
@@ -473,7 +473,7 @@ PREAMBLE = Template(r"""
   };
 
   \node[anchor=east,white] at ([yshift=0.7in,xshift=-1in]current page.south east) {
-    \headerFontWithFallback{$header_footer_font} \fontsize{13pt}{0pt}\selectfont \thepage
+    \headerFontWithFallback{$header_footer_font}{} \fontsize{13pt}{0pt}\selectfont \thepage
   };
   \end{tikzpicture}%
   }
@@ -488,7 +488,7 @@ PREAMBLE = Template(r"""
   };
 
   \node[anchor=west,white] at ([yshift=0.7in,xshift=1in]current page.south west) {
-    \headerFontWithFallback{$header_footer_font} \fontsize{13pt}{0pt}\selectfont \thepage
+    \headerFontWithFallback{$header_footer_font}{} \fontsize{13pt}{0pt}\selectfont \thepage
   };
   \end{tikzpicture}%
   }

--- a/swift_book_pdf/preamble.py
+++ b/swift_book_pdf/preamble.py
@@ -104,7 +104,19 @@ PREAMBLE = Template(r"""
     {
       "$unicode_font:mode=harf;",
       "$emoji_font:mode=harf;",
-      "$header_footer_font:mode=harf;"
+      "$header_footer_font:mode=harf;",
+      "$mono_font:mode=harf;"
+    }
+   )
+}
+
+\directlua{luaotfload.add_fallback
+   ("headerFallback",
+    {
+      "$main_font:mode=harf;",
+      "$unicode_font:mode=harf;",
+      "$emoji_font:mode=harf;",
+      "$mono_font:mode=harf;"
     }
    )
 }
@@ -115,6 +127,10 @@ PREAMBLE = Template(r"""
 
 \newcommand{\monoFontWithFallback}[1]{%
   \fontspec{#1}[RawFeature={fallback=monoFallback}]%
+}
+
+\newcommand{\headerFontWithFallback}[1]{%
+  \fontspec{#1}[RawFeature={fallback=headerFallback}]%
 }
 
 \renewcommand{\footnotesize}{\monoFontWithFallback{$mono_font}\fontsize{8pt}{8pt}\selectfont}
@@ -394,7 +410,7 @@ PREAMBLE = Template(r"""
   };
 
   \node[anchor=east,white] at ([yshift=-0.70in,xshift=-0.95in]current page.north east) {
-    \scalebox{1.10}[1]{\fontspec{$header_footer_font}[LetterSpace=-3.5] \fontsize{13pt}{0pt}\selectfont \customheader}
+    \scalebox{1.10}[1]{\headerFontWithFallback{$header_footer_font}[LetterSpace=-3.5] \fontsize{13pt}{0pt}\selectfont \customheader}
   };
 \end{tikzpicture}%
 }
@@ -410,7 +426,7 @@ PREAMBLE = Template(r"""
 };
 
 \node[anchor=west,white] at ([yshift=-0.71in,xshift=0.95in]current page.north west) {
-  \scalebox{1.10}[1]{\fontspec{$header_footer_font}[LetterSpace=-3.5] \fontsize{13pt}{0pt}\selectfont The Swift Programming Language}
+  \scalebox{1.10}[1]{\headerFontWithFallback{$header_footer_font}[LetterSpace=-3.5] \fontsize{13pt}{0pt}\selectfont The Swift Programming Language}
 };
 \end{tikzpicture}%
 }
@@ -425,7 +441,7 @@ PREAMBLE = Template(r"""
 };
 
 \node[anchor=east,white] at ([yshift=0.7in,xshift=-1in]current page.south east) {
-  \fontspec{$header_footer_font} \fontsize{13pt}{0pt}\selectfont \thepage
+  \headerFontWithFallback{$header_footer_font} \fontsize{13pt}{0pt}\selectfont \thepage
 };
 \end{tikzpicture}%
 }
@@ -440,7 +456,7 @@ PREAMBLE = Template(r"""
 };
 
 \node[anchor=west,white] at ([yshift=0.7in,xshift=1in]current page.south west) {
-  \fontspec{$header_footer_font} \fontsize{13pt}{0pt}\selectfont \thepage
+  \headerFontWithFallback{$header_footer_font} \fontsize{13pt}{0pt}\selectfont \thepage
 };
 \end{tikzpicture}%
 }
@@ -457,7 +473,7 @@ PREAMBLE = Template(r"""
   };
 
   \node[anchor=east,white] at ([yshift=0.7in,xshift=-1in]current page.south east) {
-    \fontspec{$header_footer_font} \fontsize{13pt}{0pt}\selectfont \thepage
+    \headerFontWithFallback{$header_footer_font} \fontsize{13pt}{0pt}\selectfont \thepage
   };
   \end{tikzpicture}%
   }
@@ -472,7 +488,7 @@ PREAMBLE = Template(r"""
   };
 
   \node[anchor=west,white] at ([yshift=0.7in,xshift=1in]current page.south west) {
-    \fontspec{$header_footer_font} \fontsize{13pt}{0pt}\selectfont \thepage
+    \headerFontWithFallback{$header_footer_font} \fontsize{13pt}{0pt}\selectfont \thepage
   };
   \end{tikzpicture}%
   }

--- a/swift_book_pdf/preamble.py
+++ b/swift_book_pdf/preamble.py
@@ -88,10 +88,39 @@ PREAMBLE = Template(r"""
 \setlength\parindent{0pt}
 \setcounter{secnumdepth}{4}
 
-\renewcommand{\footnotesize}{\fontspec{$mono_font}\fontsize{8pt}{8pt}\selectfont}
+\directlua{luaotfload.add_fallback
+   ("monoFallback",
+    {
+      "$main_font:mode=harf;",
+      "$unicode_font:mode=harf;",
+      "$emoji_font:mode=harf;",
+      "$header_footer_font:mode=harf;"
+    }
+   )
+}
+
+\directlua{luaotfload.add_fallback
+   ("mainFontFallback",
+    {
+      "$unicode_font:mode=harf;",
+      "$emoji_font:mode=harf;",
+      "$header_footer_font:mode=harf;"
+    }
+   )
+}
+
+\newcommand{\mainFontWithFallback}[1]{%
+ \fontspec{#1}[RawFeature={fallback=mainFontFallback}]%
+}
+
+\newcommand{\monoFontWithFallback}[1]{%
+  \fontspec{#1}[RawFeature={fallback=monoFallback}]%
+}
+
+\renewcommand{\footnotesize}{\monoFontWithFallback{$mono_font}\fontsize{8pt}{8pt}\selectfont}
 \setlength{\footnotesep}{9pt}
 \makeatletter
-\renewcommand{\@makefnmark}{\fontspec{$main_font}\selectfont\textsuperscript\@thefnmark}
+\renewcommand{\@makefnmark}{\mainFontWithFallback{$main_font}\selectfont\textsuperscript\@thefnmark}
 \renewcommand{\@makefntext}[1]{%
   \@hangfrom{\hbox{\@makefnmark\ }}#1%
 }
@@ -99,15 +128,15 @@ PREAMBLE = Template(r"""
 \renewcommand{\thempfootnote}{\arabic{mpfootnote}}
 
 \newcommand{\TitleStyle}{%
-  \fontspec{$main_font}\fontsize{22pt}{1.2\baselineskip}\selectfont
+  \mainFontWithFallback{$main_font}\fontsize{22pt}{1.2\baselineskip}\selectfont
 }
 
 \newcommand{\SubtitleStyle}{%
-\global\precededbyboxfalse\fontspec{$main_font}\fontsize{11.07pt}{1.2\baselineskip}\selectfont
+\global\precededbyboxfalse\mainFontWithFallback{$main_font}\fontsize{11.07pt}{1.2\baselineskip}\selectfont
 }
 
 \newcommand{\BodyStyle}{%
-\fontspec{$main_font}\fontsize{9pt}{1.15\baselineskip}\selectfont\setlength{\parskip}{0.09in}\raggedright
+\mainFontWithFallback{$main_font}\fontsize{9pt}{1.15\baselineskip}\selectfont\setlength{\parskip}{0.09in}\raggedright
 }
 
 \newcommand{\ParagraphStyle}[1]{%
@@ -129,7 +158,7 @@ PREAMBLE = Template(r"""
 \def\section{\@startsection{section}{1}{0pt}%
    {0.4in}
    {0.1in}
-   {\fontspec{$main_font}\fontsize{22pt}{1.5\baselineskip}\selectfont\global\AtPageTopfalse}}
+   {\mainFontWithFallback{$main_font}\fontsize{22pt}{1.5\baselineskip}\selectfont\global\AtPageTopfalse}}
 \makeatother
 
 \newcommand{\TitleSection}[2]{%
@@ -142,7 +171,7 @@ PREAMBLE = Template(r"""
 \def\subsection{\@startsection{subsection}{2}{0pt}%
    {\ifprecededbyparagraph 0.44in \else 0.41in \fi}
    {0.16in}
-   {\fontspec{$main_font}\fontsize{16.88pt}{1.5\baselineskip}\selectfont\global\precededbysectiontrue\global\precededbyparagraphfalse\global\precededbyboxfalse\global\precededbynotefalse\global\AtPageTopfalse}}
+   {\mainFontWithFallback{$main_font}\fontsize{16.88pt}{1.5\baselineskip}\selectfont\global\precededbysectiontrue\global\precededbyparagraphfalse\global\precededbyboxfalse\global\precededbynotefalse\global\AtPageTopfalse}}
 \makeatother
 
 \newcommand{\SectionHeader}[2]{%
@@ -166,7 +195,7 @@ PREAMBLE = Template(r"""
 \def\subsubsection{\@startsection{subsubsection}{3}{0pt}%
    {\ifAtPageTop \ifintoc 0in \else \ifprecededbyparagraph 0.37in \else 0.35in \fi \fi \else \ifprecededbyparagraph 0.37in \else 0.35in \fi \fi}
    {0.16in}
-   {\fontspec{$main_font}\fontsize{14.77pt}{1.5\baselineskip}\selectfont\global\precededbysectiontrue\global\precededbyparagraphfalse\global\precededbyboxfalse\global\precededbynotefalse\global\AtPageTopfalse}}
+   {\mainFontWithFallback{$main_font}\fontsize{14.77pt}{1.5\baselineskip}\selectfont\global\precededbysectiontrue\global\precededbyparagraphfalse\global\precededbyboxfalse\global\precededbynotefalse\global\AtPageTopfalse}}
 \makeatother
 
 \newcommand{\SubsectionHeader}[2]{%
@@ -199,7 +228,7 @@ PREAMBLE = Template(r"""
 \def\paragraph{\@startsection{paragraph}{4}{0pt}%
    {\ifprecededbyparagraph 0.34in \else 0.32in \fi}
    {0.16in}
-   {\bfseries\fontspec{$main_font}\fontsize{12.66}{1.5\baselineskip}\selectfont\global\precededbysectiontrue\global\precededbyparagraphfalse\global\precededbyboxfalse\global\precededbynotefalse\global\AtPageTopfalse}}
+   {\bfseries\mainFontWithFallback{$main_font}\fontsize{12.66}{1.5\baselineskip}\selectfont\global\precededbysectiontrue\global\precededbyparagraphfalse\global\precededbyboxfalse\global\precededbynotefalse\global\AtPageTopfalse}}
 \makeatother
 
 \newcommand{\SubsubsectionHeader}[2]{%
@@ -212,10 +241,10 @@ PREAMBLE = Template(r"""
 }
 
 \newcommand{\CodeStyle}{%
-  \fontspec{$mono_font}\fontsize{9pt}{1.1\baselineskip}\selectfont
+  \monoFontWithFallback{$mono_font}\fontsize{9pt}{1.1\baselineskip}\selectfont
   \setlength{\parskip}{7pt}\raggedright
 }
-\setmonofont{$mono_font}[Scale=1]
+\setmonofont{$mono_font}[RawFeature={fallback=monoFallback}]
 
 % Define custom emoji style for code
 \newfontfamily\emoji{$emoji_font}[Renderer=Harfbuzz]


### PR DESCRIPTION
Removes special handling of Unicode + Emoji characters and relies on fallback fonts to render all characters. This change makes it easier to fall through all available fonts in case we can render the character with one of the other available fonts.

There are still some characters, however, that require special handling before typesetting. Currently, the only character in this category is é⃝, which is typeset as `\textcircled{é}`. See the new `override_characters` function.