### PR TITLE
fix/ Add shell escape option for MiKTeX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- Fix an issue where the minted package could not shell escape in systems running MiKTeX.
+
 ## [1.2.0] - 2025-03-15
 
 ### Added

--- a/swift_book_pdf/pdf.py
+++ b/swift_book_pdf/pdf.py
@@ -39,7 +39,7 @@ class PDFConverter:
         )
 
         process = subprocess.Popen(
-            ["lualatex", "--shell-escape", latex_file_path],
+            ["lualatex", "--shell-escape", "--enable-write18", latex_file_path],
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             universal_newlines=True,


### PR DESCRIPTION
Adds the `--enable-write18` option in the `lualatex` call, in addition to `--shell-escape`.

From the [minted docs](https://ctan.math.illinois.edu/macros/latex/contrib/minted/minted.pdf) (p.8):
> For versions of TeX Live before 2024 and for MiKTeX, latexminted requires special permission to run. This can be accomplished by running LaTeX with the `--shell-escape` option (TeX Live) or the `--enable-write18` option (MiKTeX).