### PR TITLE
fix/ Internal references may not populate properly in Windows systems

### DIFF
--- a/swift_book_pdf/files.py
+++ b/swift_book_pdf/files.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 
 def get_file_name(file_path: str) -> str:
-    return file_path.split("/")[-1].replace(".md", "")
+    return os.path.basename(file_path).replace(".md", "")
 
 
 def clone_swift_book_repo(temp: str) -> None:


### PR DESCRIPTION
Fixes an issue where internal references might not populate properly in Windows systems. 

This issue was caused by the `get_file_name` function. The previous `file_path.split("/")[-1]` approach did not work in Windows systems, where `\`s might be included in the file path.