### PR TITLE
fix/ Incorrect asset paths on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix an issue where the minted package could not shell escape in systems running MiKTeX.
 - Fix an issue where internal references might not populate properly in Windows systems.
 - Fix an issue where logs might not render properly because of an incorrect encoding issue, causing the entire typesetting process to fail.
+- Fix an issue where image paths passed to LaTeX were not following the Unix style on Windows.
 
 ### Changed
 - When rendering unsupported characters, fall through all available fonts in case the character is supported by one of the other available fonts.

--- a/swift_book_pdf/latex_helpers.py
+++ b/swift_book_pdf/latex_helpers.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+from pathlib import PureWindowsPath
 import re
 import struct
 
@@ -323,7 +324,8 @@ def convert_blocks_to_latex(
             imgname = block.imgname
 
             img_path = os.path.join(assets_dir, f"{imgname}@2x.png")
-            img_path = img_path.replace("\\", "/")
+            if os.sep == '\\':
+                img_path = PureWindowsPath(img_path).as_posix()
             final_width = "auto"
             width = None
             try:

--- a/swift_book_pdf/latex_helpers.py
+++ b/swift_book_pdf/latex_helpers.py
@@ -323,6 +323,7 @@ def convert_blocks_to_latex(
             imgname = block.imgname
 
             img_path = os.path.join(assets_dir, f"{imgname}@2x.png")
+            img_path = img_path.replace("\\", "/")
             final_width = "auto"
             width = None
             try:


### PR DESCRIPTION
Fixes an issue where image paths passed to LaTeX were not following the Unix style on Windows.