### PR TITLE
fix/ Cannot overwrite existing file on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 - Fix an issue where the minted package could not shell escape in systems running MiKTeX.
 - Fix an issue where internal references might not populate properly in Windows systems.
 - Fix an issue where logs might not render properly because of an incorrect encoding issue, causing the entire typesetting process to fail.
-- Fix an issue where image paths passed to LaTeX were not following the Unix style on Windows.
+- Fix an issue where image paths passed to LaTeX were not following the Unix style in Windows systems.
+- Fix an issue where the output file could not be saved by overwriting an existing file in Windows systems.
 
 ### Changed
 - When rendering unsupported characters, fall through all available fonts in case the character is supported by one of the other available fonts.

--- a/swift_book_pdf/book.py
+++ b/swift_book_pdf/book.py
@@ -64,5 +64,8 @@ class Book:
             logger.error(f"PDF file not found: {temp_pdf_path}")
             return
 
-        os.replace(temp_pdf_path, self.config.output_path)
-        logger.info(f"PDF saved to {self.config.output_path}")
+        try:
+            os.replace(temp_pdf_path, self.config.output_path)
+            logger.info(f"PDF saved to {self.config.output_path}")
+        except OSError as e:
+            logger.error(f"Failed to save PDF to {self.config.output_path}. Error overwriting existing file at destination: {e}")

--- a/swift_book_pdf/book.py
+++ b/swift_book_pdf/book.py
@@ -68,7 +68,11 @@ class Book:
             logger.debug(
                 f"File already exists at {self.config.output_path}. It will be replaced."
             )
-            os.remove(self.config.output_path)
+            try:
+                os.remove(self.config.output_path)
+            except OSError as e:
+                logger.error(f"Error overwriting file {self.config.output_path}: {e}")
+                return
 
         os.rename(temp_pdf_path, self.config.output_path)
         logger.info(f"PDF saved to {self.config.output_path}")

--- a/swift_book_pdf/book.py
+++ b/swift_book_pdf/book.py
@@ -64,15 +64,5 @@ class Book:
             logger.error(f"PDF file not found: {temp_pdf_path}")
             return
 
-        if os.path.exists(self.config.output_path):
-            logger.debug(
-                f"File already exists at {self.config.output_path}. It will be replaced."
-            )
-            try:
-                os.remove(self.config.output_path)
-            except OSError as e:
-                logger.error(f"Error overwriting file {self.config.output_path}: {e}")
-                return
-
-        os.rename(temp_pdf_path, self.config.output_path)
+        os.replace(temp_pdf_path, self.config.output_path)
         logger.info(f"PDF saved to {self.config.output_path}")

--- a/swift_book_pdf/book.py
+++ b/swift_book_pdf/book.py
@@ -64,5 +64,11 @@ class Book:
             logger.error(f"PDF file not found: {temp_pdf_path}")
             return
 
+        if os.path.exists(self.config.output_path):
+            logger.debug(
+                f"File already exists at {self.config.output_path}. It will be replaced."
+            )
+            os.remove(self.config.output_path)
+
         os.rename(temp_pdf_path, self.config.output_path)
         logger.info(f"PDF saved to {self.config.output_path}")

--- a/swift_book_pdf/book.py
+++ b/swift_book_pdf/book.py
@@ -68,4 +68,6 @@ class Book:
             os.replace(temp_pdf_path, self.config.output_path)
             logger.info(f"PDF saved to {self.config.output_path}")
         except OSError as e:
-            logger.error(f"Failed to save PDF to {self.config.output_path}. Error overwriting existing file at destination: {e}")
+            logger.error(
+                f"Failed to save PDF to {self.config.output_path}. Error overwriting existing file at destination: {e}"
+            )

--- a/swift_book_pdf/latex_helpers.py
+++ b/swift_book_pdf/latex_helpers.py
@@ -324,7 +324,7 @@ def convert_blocks_to_latex(
             imgname = block.imgname
 
             img_path = os.path.join(assets_dir, f"{imgname}@2x.png")
-            if os.sep == '\\':
+            if os.sep == "\\":
                 img_path = PureWindowsPath(img_path).as_posix()
             final_width = "auto"
             width = None


### PR DESCRIPTION
Fixes an issue where the output file could not be saved by overwriting an existing file in Windows systems.