### PR TITLE
fix/ Accepted Unicode fonts may not be all-encompassing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Added
-- Added new "Global" font category as a unicode font for additional characters not supported by the main font, e.g. Chinese characters. The same font can be used both for Global and Unicode categories if it includes all required glyphs (e.g. Arial Unicode MS).
+- Add new "Global" font category as a unicode font for additional characters not supported by the main font, e.g. Chinese characters. The same font can be used both for Global and Unicode categories if it includes all required glyphs (e.g. Arial Unicode MS).
 
 ### Fixed
 - Fix an issue where the minted package could not shell escape in systems running MiKTeX.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,16 @@
 
 ## [Unreleased]
 
+### Added
+- Added new "Global" font category as a unicode font for additional characters not supported by the main font, e.g. Chinese characters. The same font can be used both for Global and Unicode categories if it includes all required glyphs (e.g. Arial Unicode MS).
+
 ### Fixed
 - Fix an issue where the minted package could not shell escape in systems running MiKTeX.
 - Fix an issue where internal references might not populate properly in Windows systems.
 - Fix an issue where logs might not render properly because of an incorrect encoding issue, causing the entire typesetting process to fail.
 - Fix an issue where image paths passed to LaTeX were not following the Unix style in Windows systems.
 - Fix an issue where the output file could not be saved by overwriting an existing file in Windows systems.
+- Fix an issue where an accepted Unicode font may not support all required glyphs.
 
 ### Changed
 - When rendering unsupported characters, fall through all available fonts in case the character is supported by one of the other available fonts.

--- a/swift_book_pdf/cli.py
+++ b/swift_book_pdf/cli.py
@@ -82,6 +82,13 @@ def cli() -> None:
     help="Font for characters not supported by the main font",
 )
 @click.option(
+    "--global",
+    "_global",
+    type=str,
+    default=None,
+    help="Secondary unicode font for additional characters not supported by the main font, e.g. Chinese characters",
+)
+@click.option(
     "--emoji",
     type=str,
     default=None,
@@ -104,6 +111,7 @@ def run(
     main: Optional[str],
     mono: Optional[str],
     unicode: Optional[str],
+    _global: Optional[str],
     emoji: Optional[str],
     header_footer: Optional[str],
     version: bool,
@@ -122,6 +130,7 @@ def run(
             main_font_custom=main,
             mono_font_custom=mono,
             unicode_font_custom=unicode,
+            global_font_custom=_global,
             emoji_font_custom=emoji,
             header_footer_font_custom=header_footer,
         )

--- a/swift_book_pdf/preamble.py
+++ b/swift_book_pdf/preamble.py
@@ -43,6 +43,7 @@ def generate_preamble(config: Config) -> str:
         mono_font=config.font_config.mono_font,
         emoji_font=config.font_config.emoji_font,
         unicode_font=config.font_config.unicode_font,
+        global_font=config.font_config.global_font,
         header_footer_font=config.font_config.header_footer_font,
     )
 
@@ -91,10 +92,11 @@ PREAMBLE = Template(r"""
 \directlua{luaotfload.add_fallback
    ("monoFallback",
     {
-      "$main_font:mode=harf;",
-      "$unicode_font:mode=harf;",
+      "$main_font:mode=node;",
+      "$unicode_font:mode=node;",
+      "$global_font:mode=node;",
       "$emoji_font:mode=harf;",
-      "$header_footer_font:mode=harf;"
+      "$header_footer_font:mode=node;"
     }
    )
 }
@@ -102,10 +104,11 @@ PREAMBLE = Template(r"""
 \directlua{luaotfload.add_fallback
    ("mainFontFallback",
     {
-      "$unicode_font:mode=harf;",
+      "$unicode_font:mode=node;",
+      "$global_font:mode=node;",
       "$emoji_font:mode=harf;",
-      "$header_footer_font:mode=harf;",
-      "$mono_font:mode=harf;"
+      "$header_footer_font:mode=node;",
+      "$mono_font:mode=node;"
     }
    )
 }
@@ -113,10 +116,11 @@ PREAMBLE = Template(r"""
 \directlua{luaotfload.add_fallback
    ("headerFallback",
     {
-      "$main_font:mode=harf;",
-      "$unicode_font:mode=harf;",
+      "$main_font:mode=node;",
+      "$unicode_font:mode=node;",
+      "$global_font:mode=node;",
       "$emoji_font:mode=harf;",
-      "$mono_font:mode=harf;"
+      "$mono_font:mode=node;"
     }
    )
 }
@@ -261,12 +265,6 @@ PREAMBLE = Template(r"""
   \setlength{\parskip}{7pt}\raggedright
 }
 \setmonofont{$mono_font}[RawFeature={fallback=monoFallback}, Scale=1]
-
-% Define custom emoji style for code
-\newfontfamily\emoji{$emoji_font}[Renderer=Harfbuzz]
-\newfontfamily\unicodeFont{$unicode_font}[Renderer=Harfbuzz]
-\newcommand{\loweremoji}[1]{\raisebox{-0.2ex}{#1}}
-\newcommand{\textNonLatin}[1]{\unicodeFont{#1}}
 
 % ----------------------------------------
 % Define custom property for padding


### PR DESCRIPTION
Fixes an issue where an accepted Unicode font may not support all required glyphs. Adds a new "Global" font category as a unicode font for additional characters not supported by the main font, e.g. Chinese characters. The same font can be used both for Global and Unicode categories if it includes all required glyphs (e.g. Arial Unicode MS).