### PR TITLE
fix/ Kill LaTeX process when a font issue is raised

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fix an issue where image paths passed to LaTeX were not following the Unix style in Windows systems.
 - Fix an issue where the output file could not be saved by overwriting an existing file in Windows systems.
 - Fix an issue where an accepted Unicode font may not support all required glyphs.
+- Fix an issue where the LaTeX typesetting process may continue even after a font error is raised.
 
 ### Changed
 - When rendering unsupported characters, fall through all available fonts in case the character is supported by one of the other available fonts.

--- a/swift_book_pdf/log.py
+++ b/swift_book_pdf/log.py
@@ -88,7 +88,7 @@ def run_process_with_logs(
             sys.stdout.write("\033[F")
 
         sys.stdout.flush()
-    except Exception as e:
+    except:
         process.kill()
         process.wait()
-        raise e
+        raise


### PR DESCRIPTION
Fixes an issue where the LaTeX typesetting process may continue even after a font error is raised.