### PR TITLE
fix/ Rely on first reference-style name for external links

### DIFF
--- a/swift_book_pdf/markdown_helpers.py
+++ b/swift_book_pdf/markdown_helpers.py
@@ -63,7 +63,7 @@ def convert_reference_links_in_line(line: str, references: dict[str, str]) -> st
             return f"[{ref_1}]({references[ref_1]})"
         elif ref_2 and ref_2 in references:
             if ref_1:
-                return f"[{ref_2}]({references[ref_1]})"
+                return f"[{ref_1}]({references[ref_2]})"
             else:
                 return f"[{ref_2}]({references[ref_2]})"
         else:

--- a/swift_book_pdf/markdown_helpers.py
+++ b/swift_book_pdf/markdown_helpers.py
@@ -62,7 +62,10 @@ def convert_reference_links_in_line(line: str, references: dict[str, str]) -> st
         if ref_1 and ref_1 in references:
             return f"[{ref_1}]({references[ref_1]})"
         elif ref_2 and ref_2 in references:
-            return f"[{ref_2}]({references[ref_2]})"
+            if ref_1:
+                return f"[{ref_2}]({references[ref_1]})"
+            else:
+                return f"[{ref_2}]({references[ref_2]})"
         else:
             return match.group(0)
 


### PR DESCRIPTION
Fixes an issue where the incorrect label would be displayed for reference-style links.