### PR TITLE
chore/ Add `latexminted` dependency & shell escape optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 - Replace `wrap_emoji_string` and `detect_non_latin`/`wrap_non_latin` processing pipelines with `luaotfload` font fallbacks.
 - Add new `override_characters` function for characters requiring special handling before typesetting. Previously handled within `wrap_non_latin`.
 - Remove `emoji` dependency.
-- Add `latexminted` package to ensure that `minted` v3 can run correctly on all systems.
+- Add `latexminted` package dependency to ensure that `minted` v3 can run correctly on all systems.
 - Only use shell escape when using an unsupported system (TeX Live \< 2024 or MiKTeX).
 
 ## [1.2.0] - 2025-03-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Add new `override_characters` function for characters requiring special handling before typesetting. Previously handled within `wrap_non_latin`.
 - Remove `emoji` dependency.
 - Add `latexminted` package to ensure that `minted` v3 can run correctly on all systems.
+- Only use shell escape when using an unsupported system (TeX Live \< 2024 or MiKTeX).
 
 ## [1.2.0] - 2025-03-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Replace `wrap_emoji_string` and `detect_non_latin`/`wrap_non_latin` processing pipelines with `luaotfload` font fallbacks.
 - Add new `override_characters` function for characters requiring special handling before typesetting. Previously handled within `wrap_non_latin`.
 - Remove `emoji` dependency.
+- Add `latexminted` package to ensure that `minted` v3 can run correctly on all systems.
 
 ## [1.2.0] - 2025-03-15
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -97,6 +97,47 @@ files = [
 license = ["ukkonen"]
 
 [[package]]
+name = "latex2pydata"
+version = "0.5.0"
+description = "Load data from LaTeX in Python literal format"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "latex2pydata-0.5.0-py3-none-any.whl", hash = "sha256:7c4092562082985453f47f52db31e1f8c2edcf5d7f855f4c614cfba12808675b"},
+    {file = "latex2pydata-0.5.0.tar.gz", hash = "sha256:bccad2083c3a6ed70492653d5d819ccd9360a3afc3c319dbecf496fba0574289"},
+]
+
+[[package]]
+name = "latexminted"
+version = "0.5.0"
+description = "Python library for LaTeX minted package"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "latexminted-0.5.0-py3-none-any.whl", hash = "sha256:7da8e2489709cee1981018683fcc2d31bd8e1e225367f3fdc8fae00f26d2d61e"},
+    {file = "latexminted-0.5.0.tar.gz", hash = "sha256:b108885409aa6414b2af2048bda7ec553515b976df2497e9370c43f2c9462500"},
+]
+
+[package.dependencies]
+latex2pydata = ">=0.5.0"
+latexrestricted = ">=0.6.2"
+pygments = ">=2.17.0"
+
+[[package]]
+name = "latexrestricted"
+version = "0.6.2"
+description = "Library for creating Python executables compatible with LaTeX restricted shell escape"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "latexrestricted-0.6.2-py3-none-any.whl", hash = "sha256:993bcc1c2a0484e95ce8f167bd8ec19de18cc7386cdb2d1f55d839d036eed590"},
+    {file = "latexrestricted-0.6.2.tar.gz", hash = "sha256:d51d21a41197a581ff29c0f818551f16fa0e6890def929799ac0bde762a7aa60"},
+]
+
+[[package]]
 name = "nodeenv"
 version = "1.9.1"
 description = "Node.js virtual environment builder"
@@ -414,4 +455,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9"
-content-hash = "d3f3ab344ddb3f657453e03aedff4f9a1bfcf088f70a2f050f2e721600b341fc"
+content-hash = "fdb87f0d971aeebcdba9ff96131d1a3be8cd4a2fad1b27e0386c834d203d39cb"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 authors = [{ name = "Evangelos Kassos", email = "github@evangeloskassos.com" }]
 keywords = ["swift", "book", "pdf"]
 requires-python = ">=3.9"
-dependencies = ["pygments (>=2.9.0,<3.0.0)", "tqdm (>=4.67.1,<5.0.0)", "pydantic (>=2.10.6,<3.0.0)", "click (>=8.1.8,<9.0.0)"]
+dependencies = ["pygments (>=2.9.0,<3.0.0)", "tqdm (>=4.67.1,<5.0.0)", "pydantic (>=2.10.6,<3.0.0)", "click (>=8.1.8,<9.0.0)", "latexminted (>=0.5.0,<0.6.0)"]
 
 [project.urls]
 repository = "https://github.com/ekassos/swift-book-pdf.git"

--- a/swift_book_pdf/pdf.py
+++ b/swift_book_pdf/pdf.py
@@ -43,7 +43,7 @@ class PDFConverter:
         )
 
         if result.returncode != 0:
-            raise RuntimeError("Failed to get LaTeX version")
+            raise RuntimeError(f"Failed to get LaTeX version: {result.stderr}")
 
         match = re.search(pattern, result.stdout)
         if match:
@@ -62,7 +62,7 @@ class PDFConverter:
                     f"Unsupported LaTeX distribution: {tex_distribution}"
                 )
         else:
-            raise RuntimeError("Failed to parse LaTeX version")
+            raise RuntimeError(f"Failed to get LaTeX version: {result.stderr}")
         logger.debug(
             f"Using LaTeX distribution: {tex_distribution}, version: {tex_version}"
         )

--- a/swift_book_pdf/pdf.py
+++ b/swift_book_pdf/pdf.py
@@ -12,12 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import os
+import re
 import subprocess
 
 from swift_book_pdf.config import Config
 from swift_book_pdf.fonts import check_for_missing_font_logs
 from swift_book_pdf.log import run_process_with_logs
+
+logger = logging.getLogger(__name__)
 
 
 class PDFConverter:
@@ -26,6 +30,44 @@ class PDFConverter:
             os.path.dirname(os.path.abspath(__file__)), "assets"
         )
         self.config = config
+
+    def get_latex_command(self) -> list[str]:
+        command = ["lualatex", "--interaction=nonstopmode"]
+
+        pattern = r"(TeX Live|MiKTeX) (\d{2,4})"
+
+        result = subprocess.run(
+            ["lualatex", "--version"],
+            capture_output=True,
+            text=True,
+        )
+
+        if result.returncode != 0:
+            raise RuntimeError("Failed to get LaTeX version")
+
+        match = re.search(pattern, result.stdout)
+        if match:
+            tex_distribution = match.group(1)
+            tex_version = match.group(2)
+
+            if tex_distribution == "TeX Live":
+                if int(tex_version) < 2024:
+                    command.append("--shell-escape")
+                    command.append("--enable-write18")
+            elif tex_distribution == "MiKTeX":
+                command.append("--shell-escape")
+                command.append("--enable-write18")
+            else:
+                raise RuntimeError(
+                    f"Unsupported LaTeX distribution: {tex_distribution}"
+                )
+        else:
+            raise RuntimeError("Failed to parse LaTeX version")
+        logger.debug(
+            f"Using LaTeX distribution: {tex_distribution}, version: {tex_version}"
+        )
+        logger.debug(f"LaTeX Command: {command}")
+        return command
 
     def convert_to_pdf(self, latex_file_path: str) -> None:
         env = os.environ.copy()
@@ -39,7 +81,7 @@ class PDFConverter:
         )
 
         process = subprocess.Popen(
-            ["lualatex", "--shell-escape", "--enable-write18", latex_file_path],
+            self.get_latex_command() + [latex_file_path],
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             text=True,


### PR DESCRIPTION
Add `latexminted` package dependency to ensure that `minted` v3 can run correctly on all systems. Only use shell escape when using an unsupported system (TeX Live < 2024 or MiKTeX).