### PR TITLE
fix/ Inefficient regular expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Internal
+- Change regular expression used for detecting URLs in Markdown that may have caused exponential backtracking on strings starting with '[\](http://' and containing many repetitions of '!'.
+
 ## [1.3.0] - 2025-03-23
 
 ### Added

--- a/swift_book_pdf/latex_helpers.py
+++ b/swift_book_pdf/latex_helpers.py
@@ -147,7 +147,7 @@ def apply_formatting(text: str, mode: RenderingMode) -> str:
     text = re.sub(r"\*(.+?)\*", r"\\emph{\1}", text)
     text = re.sub(r"\s\\\s", r" \\\\ ", text)
     text = re.sub(
-        r"\[([^\]]+)\]\((https?:\/\/(?:[^()\s]+|\([^()]*\))+)\)",
+        r"\[([^\]]+)\]\((https?:\/\/[^\s()]+(?:\([^()]*\)[^\s()]*)*)\)",
         (
             r"\\href{\2}{\1}\\footnote{\\url{\2}}"
             if mode == RenderingMode.PRINT


### PR DESCRIPTION
Change regular expression used for detecting URLs in Markdown that may have caused exponential backtracking on strings starting with '[\](http://' and containing many repetitions of '!'.