### PR TITLE
feat/ Option to use local version of the `swift-book` repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Add new `--dark` flag to enable rendering in dark mode.
+- Add new `--input-path`/`-i` option to use local copy of the swift-book repo.
 
 ### Internal
 - Change regular expression used for detecting URLs in Markdown that may have caused exponential backtracking on strings starting with '[\](http://' and containing many repetitions of '!'.

--- a/swift_book_pdf/cli.py
+++ b/swift_book_pdf/cli.py
@@ -95,6 +95,14 @@ def cli() -> None:
     help="Font for text in the header and footer",
 )
 @click.option("--dark", is_flag=True, help="Render the book in dark mode")
+@click.option(
+    "--input-path",
+    "-i",
+    help="Path to the root of a local copy of the swift-book repo. If not provided,\
+        the repository will be cloned from GitHub.",
+    type=click.Path(resolve_path=True),
+    required=False,
+)
 @click.option("--verbose", is_flag=True)
 @click.option("--version", is_flag=True)
 def run(
@@ -110,6 +118,7 @@ def run(
     header_footer: Optional[str],
     dark: bool,
     version: bool,
+    input_path: Optional[str] = None,
 ) -> None:
     if version:
         current_version = importlib.metadata.version("swift-book-pdf")
@@ -134,7 +143,7 @@ def run(
         return
 
     with TemporaryDirectory() as temp:
-        config = Config(temp, output_path, font_config, doc_config)
+        config = Config(temp, output_path, font_config, doc_config, input_path)
         try:
             Book(config).process()
         except Exception as e:

--- a/swift_book_pdf/config.py
+++ b/swift_book_pdf/config.py
@@ -13,10 +13,9 @@
 # limitations under the License.
 
 import logging
-import os
 import shutil
 from swift_book_pdf.doc import DocConfig
-from swift_book_pdf.files import clone_swift_book_repo
+from swift_book_pdf.files import find_or_clone_swift_book_repo
 from swift_book_pdf.fonts import FontConfig
 
 logger = logging.getLogger(__name__)
@@ -25,34 +24,29 @@ logger = logging.getLogger(__name__)
 class Config:
     def __init__(
         self,
-        input_path: str,
+        temp_dir_path: str,
         output_path: str,
         font_config: FontConfig,
         doc_config: DocConfig,
+        input_path: str | None = None,
     ):
         if not shutil.which("git"):
             raise RuntimeError("Git is not installed or not in PATH.")
 
-        self.temp_dir = input_path
+        self.temp_dir = temp_dir_path
 
-        logger.info("Downloading TSPL files...")
-        clone_swift_book_repo(input_path)
-        self.root_dir = os.path.join(input_path, "swift-book/TSPL.docc/")
+        file_paths = find_or_clone_swift_book_repo(temp_dir_path, input_path)
 
-        self.toc_file_path = os.path.join(
-            self.root_dir, "The-Swift-Programming-Language.md"
-        )
-        if not os.path.exists(self.toc_file_path):
-            raise FileNotFoundError(
-                f"Couldn't find the Table of Contents file (The-Swift-Programming-Language.md) in {self.root_dir}."
-            )
-
-        self.assets_dir = os.path.join(self.root_dir, "Assets/")
-        if not os.path.exists(self.assets_dir):
-            raise FileNotFoundError(
-                f"Couldn't find the Assets directory ({self.assets_dir})."
-            )
-
+        self.root_dir = file_paths.root_dir
+        self.toc_file_path = file_paths.toc_file_path
+        self.assets_dir = file_paths.assets_dir
         self.output_path = output_path
         self.font_config = font_config
         self.doc_config = doc_config
+        logger.debug(f"Swift book repository cloned to {self.root_dir}")
+        logger.debug(f"Assets directory: {self.assets_dir}")
+        logger.debug(f"Output path: {self.output_path}")
+        logger.debug(f"Font configuration: {self.font_config}")
+        logger.debug(f"Document configuration: {self.doc_config}")
+        logger.debug(f"Temporary directory: {self.temp_dir}")
+        logger.debug(f"Table of contents file path: {self.toc_file_path}")

--- a/swift_book_pdf/config.py
+++ b/swift_book_pdf/config.py
@@ -43,7 +43,7 @@ class Config:
         self.output_path = output_path
         self.font_config = font_config
         self.doc_config = doc_config
-        logger.debug(f"Swift book repository cloned to {self.root_dir}")
+        logger.debug(f"Swift book repository directory: {self.root_dir}")
         logger.debug(f"Assets directory: {self.assets_dir}")
         logger.debug(f"Output path: {self.output_path}")
         logger.debug(f"Font configuration: {self.font_config}")

--- a/swift_book_pdf/files.py
+++ b/swift_book_pdf/files.py
@@ -80,7 +80,7 @@ def find_or_clone_swift_book_repo(
             f"Couldn't find the Table of Contents file (The-Swift-Programming-Language.md) in {root_dir}."
         )
 
-    assets_dir = os.path.join(clone_dir, "Assets/")
+    assets_dir = os.path.join(root_dir, "Assets/")
     if not os.path.exists(assets_dir):
         raise FileNotFoundError(f"Couldn't find the Assets directory ({assets_dir}).")
     return SwiftBookRepoFilePaths(

--- a/swift_book_pdf/files.py
+++ b/swift_book_pdf/files.py
@@ -15,6 +15,9 @@
 import logging
 import os
 import subprocess
+from typing import Optional
+
+from .schema import SwiftBookRepoFilePaths
 
 logger = logging.getLogger(__name__)
 
@@ -23,13 +26,41 @@ def get_file_name(file_path: str) -> str:
     return os.path.basename(file_path).replace(".md", "")
 
 
-def clone_swift_book_repo(temp: str) -> None:
+def find_or_clone_swift_book_repo(
+    temp: str, input_path: Optional[str] = None
+) -> SwiftBookRepoFilePaths:
     """
     Clone the Swift book repository.
 
     Args:
         temp: The temporary directory to clone the repository
+        input_path: The path to the local copy of the swift-book repo, if available
     """
+    if input_path:
+        root_dir = os.path.join(input_path, "TSPL.docc/")
+        toc_file_path = os.path.join(root_dir, "The-Swift-Programming-Language.md")
+        assets_dir = os.path.join(root_dir, "Assets/")
+        if not os.path.exists(root_dir):
+            raise FileNotFoundError(
+                f"The specified input path {input_path} does not contain the Swift book repository."
+            )
+        elif not os.path.exists(toc_file_path):
+            raise FileNotFoundError(
+                f"Couldn't find the Table of Contents file (The-Swift-Programming-Language.md) in {root_dir}."
+            )
+        elif not os.path.exists(assets_dir):
+            raise FileNotFoundError(
+                f"Couldn't find the Assets directory ({assets_dir})."
+            )
+        else:
+            logger.info("Using local TSPL files...")
+            return SwiftBookRepoFilePaths(
+                toc_file_path=toc_file_path,
+                root_dir=root_dir,
+                assets_dir=assets_dir,
+            )
+
+    logger.info("Downloading TSPL files...")
     repo_url = "https://github.com/swiftlang/swift-book.git"
     clone_dir = os.path.join(temp, "swift-book")
 
@@ -40,6 +71,22 @@ def clone_swift_book_repo(temp: str) -> None:
         check=True,
         stdout=None if is_debug else subprocess.DEVNULL,
         stderr=None if is_debug else subprocess.DEVNULL,
+    )
+
+    root_dir = os.path.join(clone_dir, "TSPL.docc/")
+    toc_file_path = os.path.join(root_dir, "The-Swift-Programming-Language.md")
+    if not os.path.exists(toc_file_path):
+        raise FileNotFoundError(
+            f"Couldn't find the Table of Contents file (The-Swift-Programming-Language.md) in {root_dir}."
+        )
+
+    assets_dir = os.path.join(clone_dir, "Assets/")
+    if not os.path.exists(assets_dir):
+        raise FileNotFoundError(f"Couldn't find the Assets directory ({assets_dir}).")
+    return SwiftBookRepoFilePaths(
+        toc_file_path=toc_file_path,
+        root_dir=root_dir,
+        assets_dir=assets_dir,
     )
 
 

--- a/swift_book_pdf/pdf.py
+++ b/swift_book_pdf/pdf.py
@@ -32,7 +32,7 @@ class PDFConverter:
         self.config = config
 
     def get_latex_command(self) -> list[str]:
-        command = ["lualatex"]
+        command = ["lualatex", "--interaction=nonstopmode"]
 
         pattern = r"(TeX Live|MiKTeX) (\d{2,4})"
 

--- a/swift_book_pdf/pdf.py
+++ b/swift_book_pdf/pdf.py
@@ -32,7 +32,7 @@ class PDFConverter:
         self.config = config
 
     def get_latex_command(self) -> list[str]:
-        command = ["lualatex", "--interaction=nonstopmode"]
+        command = ["lualatex"]
 
         pattern = r"(TeX Live|MiKTeX) (\d{2,4})"
 

--- a/swift_book_pdf/schema.py
+++ b/swift_book_pdf/schema.py
@@ -33,6 +33,12 @@ class PaperSize(StrEnum):
     LEGAL = "legal"
 
 
+class SwiftBookRepoFilePaths(BaseModel):
+    toc_file_path: str
+    root_dir: str
+    assets_dir: str
+
+
 class ChapterMetadata(BaseModel):
     file_path: str | None = None
     header_line: str | None = None


### PR DESCRIPTION
Adds new `--input-path`/`-i` option to use local copy of the swift-book repo. If not provided, the repository will still be cloned from GitHub.