### PR TITLE
feat/ Option for typesetting without book gutter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add new `--dark` flag to enable rendering in dark mode.
 - Add new `--input-path`/`-i` option to use local copy of the swift-book repo.
 - Add a new detection mechanism for the minted requiring shell escape by typesetting a simple document containing a minted box.
+- Add new `--gutter/--no-gutter` option to control whether the typeset document has a book gutter and different layout for left/right pages.
 
 ### Fixed
 - Fix an issue where some 2024 TeX Live installations may not be able to typeset TSPL because minted still requires the `-shell-escape` option.

--- a/README.md
+++ b/README.md
@@ -89,6 +89,13 @@ swift_book_pdf --paper legal
 swift_book_pdf --dark
 ```
 
+### Book Gutter
+`swift_book_pdf` renders *The Swift Programming Language* book with a book gutter by default. To render the book without a gutter, use the `--no-gutter` flag.
+
+```
+swift_book_pdf --no-gutter
+```
+
 ### Fonts
 swift-book-pdf requires a set of fonts to typeset *The Swift Programming Language* book. You can use any of the available default options, or specify your own fonts. To learn more about fonts and available configuration options, see [this article](https://github.com/ekassos/swift-book-pdf/wiki/Fonts/).
 

--- a/swift_book_pdf/cli.py
+++ b/swift_book_pdf/cli.py
@@ -103,7 +103,12 @@ def cli() -> None:
     type=click.Path(resolve_path=True),
     required=False,
 )
-@click.option("--no-gutter", is_flag=True, help="Disable the gutter")
+@click.option(
+    "--gutter/--no-gutter",
+    " /-G",
+    required=False,
+    help="Enable or disable the book gutter",
+)
 @click.option("--verbose", is_flag=True)
 @click.option("--version", is_flag=True)
 def run(
@@ -119,8 +124,8 @@ def run(
     header_footer: Optional[str],
     dark: bool,
     version: bool,
+    gutter: bool | None = None,
     input_path: Optional[str] = None,
-    no_gutter: bool,
 ) -> None:
     if version:
         current_version = importlib.metadata.version("swift-book-pdf")
@@ -140,7 +145,7 @@ def run(
             header_footer_font_custom=header_footer,
         )
         doc_config = DocConfig(
-            RenderingMode(mode), PaperSize(paper), typesets, dark, no_gutter
+            RenderingMode(mode), PaperSize(paper), typesets, dark, gutter
         )
     except ValueError as e:
         logger.error(str(e))

--- a/swift_book_pdf/cli.py
+++ b/swift_book_pdf/cli.py
@@ -95,6 +95,7 @@ def cli() -> None:
     help="Font for text in the header and footer",
 )
 @click.option("--dark", is_flag=True, help="Render the book in dark mode")
+@click.option("--no-gutter", is_flag=True, help="Disable the gutter")
 @click.option("--verbose", is_flag=True)
 @click.option("--version", is_flag=True)
 def run(
@@ -110,6 +111,7 @@ def run(
     header_footer: Optional[str],
     dark: bool,
     version: bool,
+    no_gutter: bool,
 ) -> None:
     if version:
         current_version = importlib.metadata.version("swift-book-pdf")
@@ -128,7 +130,9 @@ def run(
             emoji_font_custom=emoji,
             header_footer_font_custom=header_footer,
         )
-        doc_config = DocConfig(RenderingMode(mode), PaperSize(paper), typesets, dark)
+        doc_config = DocConfig(
+            RenderingMode(mode), PaperSize(paper), typesets, dark, no_gutter
+        )
     except ValueError as e:
         logger.error(str(e))
         return

--- a/swift_book_pdf/doc.py
+++ b/swift_book_pdf/doc.py
@@ -22,8 +22,10 @@ class DocConfig:
         paper_size: PaperSize = PaperSize.LETTER,
         typesets: int = 4,
         dark_mode: bool = False,
+        no_gutter: bool = False,
     ):
         self.mode = mode
         self.paper_size = paper_size
         self.typesets = typesets
         self.appearance = Appearance.DARK if dark_mode else Appearance.LIGHT
+        self.gutter = not no_gutter

--- a/swift_book_pdf/doc.py
+++ b/swift_book_pdf/doc.py
@@ -28,4 +28,4 @@ class DocConfig:
         self.paper_size = paper_size
         self.typesets = typesets
         self.appearance = Appearance.DARK if dark_mode else Appearance.LIGHT
-        self.gutter = gutter or True
+        self.gutter = True if gutter is None else gutter

--- a/swift_book_pdf/doc.py
+++ b/swift_book_pdf/doc.py
@@ -22,10 +22,10 @@ class DocConfig:
         paper_size: PaperSize = PaperSize.LETTER,
         typesets: int = 4,
         dark_mode: bool = False,
-        no_gutter: bool = False,
+        gutter: bool | None = None,
     ):
         self.mode = mode
         self.paper_size = paper_size
         self.typesets = typesets
         self.appearance = Appearance.DARK if dark_mode else Appearance.LIGHT
-        self.gutter = not no_gutter
+        self.gutter = gutter or True

--- a/swift_book_pdf/preamble.py
+++ b/swift_book_pdf/preamble.py
@@ -382,7 +382,7 @@ PREAMBLE = Template(r"""
 }
 
 \newcommand{\BodyStyle}{%
-\mainFontWithFallback{$main_font}\fontsize{9pt}{1.15\baselineskip}\selectfont\setlength{\parskip}{0.09in}\justifying
+\mainFontWithFallback{$main_font}\fontsize{9pt}{1.15\baselineskip}\selectfont\setlength{\parskip}{0.09in}\raggedright
 }
 
 \newcommand{\ParagraphStyle}[1]{%
@@ -396,7 +396,6 @@ PREAMBLE = Template(r"""
 \global\AtPageTopfalse%
 \setlength{\parskip}{0.09in}%
 \begin{flushleft}%
-\justifying%
 #1%
 \end{flushleft}%
 }
@@ -605,7 +604,7 @@ PREAMBLE = Template(r"""
   after skip=0in,
   after app={\global\precededbyboxfalse\global\precededbysectionfalse\global\precededbyparagraphfalse\global\precededbynotetrue\global\AtPageTopfalse},
   left=8.8pt, right=8pt, top=8pt, bottom=8pt,
-  before upper={\justifying\color{aside_text}},
+  before upper={\raggedright\color{aside_text}},
 }
 
 


### PR DESCRIPTION
Resolves #9 by adding a new `--gutter`/`--no-gutter` option to control whether the typeset document has a book gutter and different layout for left/right pages.