### PR TITLE
Use shutil.move instead of os.replace

### DIFF
--- a/swift_book_pdf/book.py
+++ b/swift_book_pdf/book.py
@@ -14,6 +14,7 @@
 
 import os
 import logging
+import shutil
 
 from tqdm import trange
 from swift_book_pdf.config import Config
@@ -67,7 +68,7 @@ class Book:
             return
 
         try:
-            os.replace(temp_pdf_path, self.config.output_path)
+            shutil.move(temp_pdf_path, self.config.output_path)
             logger.info(f"PDF saved to {self.config.output_path}")
-        except OSError as e:
+        except (OSError, shutil.Error) as e:
             logger.error(f"Failed to save PDF to {self.config.output_path}: {e}")


### PR DESCRIPTION
This fixes the error when the output folder is not on the system's root partition (#44, #45)