### PR TITLE
fix: escape $ in paragraph text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Update `filelock` (`3.20.1` -> `3.25.2`)
   - Update `pre-commit` (`4.1.0` -> `4.5.1`)
 
+### Fixed
+- Escape literal dollar signs in paragraph text so generated LaTeX does not enter math mode and fail on currency amounts like `$1.23`.
+
 ## [2.0.1] - 2026-01-13
 ### Security
 - Update `virtualenv` (`20.35.4` -> `20.36.1`) to resolve [virtualenv Has TOCTOU Vulnerabilities in Directory Creation](https://github.com/ekassos/swift-book-pdf/security/dependabot/2). ([#51](https://github.com/ekassos/swift-book-pdf/pull/51))

--- a/swift_book_pdf/latex_helpers.py
+++ b/swift_book_pdf/latex_helpers.py
@@ -146,6 +146,10 @@ def apply_formatting(text: str, mode: RenderingMode) -> str:
 
     text = re.sub(r"(\{\\CodeStyle\s+\\texttt\{.*?\}\})", replace_inline, text)
 
+    # Escape literal currency/math markers from source text before we inject
+    # formatter-owned LaTeX snippets that intentionally use math mode.
+    text = text.replace("$", r"\$")
+
     # Apply formatting to the rest of the text.
     text = text.replace("→", r"\scalebox{1.2}{$\rightarrow$}")
     text = re.sub(r"\*\*(.+?)\*\*", r"\\textbf{\1}", text)


### PR DESCRIPTION
Escape literal dollar signs in paragraph text so generated LaTeX does not enter math mode and fail on currency amounts like `$1.23`.

Resolves #60