### PR TITLE
fix: initialize file_path variable in process_files_in_order method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Update `pre-commit` (`4.1.0` -> `4.5.1`)
 
 ### Fixed
+- Fix an issue where a chapter may appear multiple times in the generated PDF when the Markdown file for the subsequent chapter is missing.
 - Escape literal dollar signs in paragraph text so generated LaTeX does not enter math mode and fail on currency amounts like `$1.23`.
 
 ## [2.0.1] - 2026-01-13

--- a/swift_book_pdf/book.py
+++ b/swift_book_pdf/book.py
@@ -39,6 +39,7 @@ class Book:
         toc_latex, _ = self.toc.generate_toc_latex(converter=self.converter)
         latex += toc_latex + "\n"
         for tag in self.toc.doc_tags:
+            file_path = None
             chapter_metadata = self.toc.chapter_metadata.get(tag.lower())
             if chapter_metadata:
                 file_path = chapter_metadata.file_path


### PR DESCRIPTION
Resolves #67.

Resolves an issue where a chapter may appear multiple times in the generated PDF when the Markdown file for the subsequent chapter is missing. Prevent duplicate `file_path` entries in `process_markdown_file` by initializing `file_path` to `None` when a later chapter file is missing.