### PR TITLE
fix: support new upstream grammar generation scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix an issue where `Summary of the Grammar` generation could fall out of sync with the latest upstream `swift-book` repo after the summary build logic moved from `bin/publish-book` to `bin/generate-grammar`.
 
 ## [2.3.0] - 2026-04-01
 ### Added

--- a/swift_book_pdf/grammar_summary.py
+++ b/swift_book_pdf/grammar_summary.py
@@ -32,9 +32,10 @@ SUMMARY_DEFAULT_TITLE = "Summary of the Grammar"
 SUMMARY_DEFAULT_SUBTITLE = "Read the whole formal grammar."
 SUMMARY_HEADING_LINE_COUNT = 2
 SUMMARY_ECHO_PATTERN = re.compile(r'echo\s+"([^"]*)"')
+SUMMARY_SCRIPT_END_PATTERN = re.compile(r"}\s*>")
 SUMMARY_SOURCE_PATH_PATTERN = re.compile(
     r"awk -f bin/extract_grammar\.awk "
-    r"(TSPL\.docc/ReferenceManual/[A-Za-z0-9]+\.md)"
+    r"(?P<path>TSPL\.docc/ReferenceManual/[A-Za-z0-9._-]+\.md)"
 )
 SUMMARY_FALLBACK_SOURCE_PATHS = (
     "TSPL.docc/ReferenceManual/LexicalStructure.md",
@@ -87,10 +88,15 @@ def _generate_summary_file(
     temp_dir: Path,
 ) -> GeneratedSummary | None:
     publish_book_script = repo_root / "bin" / "publish-book"
-    publish_book_config = _parse_publish_book(publish_book_script)
+    generate_grammar_script = repo_root / "bin" / "generate-grammar"
+    publish_book_config = _parse_summary_config(
+        publish_book_script,
+        generate_grammar_script,
+    )
     source_paths = _resolve_summary_source_paths(
         repo_root,
         publish_book_script,
+        generate_grammar_script,
         [Path(path) for path in publish_book_config.source_paths],
     )
     if source_paths is None:
@@ -135,6 +141,45 @@ def _build_summary_text(
     )
 
 
+def _parse_summary_config(
+    publish_book_script: Path,
+    generate_grammar_script: Path,
+) -> PublishBookSummaryConfig:
+    generate_grammar_config = _parse_generate_grammar(generate_grammar_script)
+    if generate_grammar_config.source_paths:
+        return generate_grammar_config
+    return _parse_publish_book(publish_book_script)
+
+
+def _parse_generate_grammar(
+    generate_grammar_script: Path,
+) -> PublishBookSummaryConfig:
+    if not generate_grammar_script.exists():
+        return PublishBookSummaryConfig()
+
+    echo_values: list[str] = []
+    source_paths: list[Path] = []
+
+    with generate_grammar_script.open("r", encoding="utf-8") as script_file:
+        for raw_line in script_file:
+            line = raw_line.strip()
+
+            match = SUMMARY_ECHO_PATTERN.fullmatch(line)
+            if match and match.group(1):
+                echo_values.append(match.group(1))
+                if len(echo_values) > SUMMARY_HEADING_LINE_COUNT:
+                    echo_values = echo_values[:SUMMARY_HEADING_LINE_COUNT]
+
+            source_match = SUMMARY_SOURCE_PATH_PATTERN.fullmatch(line)
+            if source_match:
+                source_paths.append(
+                    generate_grammar_script.parent.parent
+                    / source_match.group("path")
+                )
+
+    return _build_summary_config(echo_values, source_paths)
+
+
 def _parse_publish_book(
     publish_book_script: Path,
 ) -> PublishBookSummaryConfig:
@@ -157,18 +202,29 @@ def _parse_publish_book(
                 in_summary_block = True
 
             if in_summary_block:
+                if SUMMARY_SCRIPT_END_PATTERN.match(line):
+                    break
+
                 match = SUMMARY_ECHO_PATTERN.fullmatch(line)
                 if match and match.group(1):
                     echo_values.append(match.group(1))
                     if len(echo_values) > SUMMARY_HEADING_LINE_COUNT:
                         echo_values = echo_values[:SUMMARY_HEADING_LINE_COUNT]
 
-            source_match = SUMMARY_SOURCE_PATH_PATTERN.search(line)
-            if source_match:
-                source_paths.append(
-                    publish_book_script.parent.parent / source_match.group(1)
-                )
+                source_match = SUMMARY_SOURCE_PATH_PATTERN.fullmatch(line)
+                if source_match:
+                    source_paths.append(
+                        publish_book_script.parent.parent
+                        / source_match.group("path")
+                    )
 
+    return _build_summary_config(echo_values, source_paths)
+
+
+def _build_summary_config(
+    echo_values: list[str],
+    source_paths: list[Path],
+) -> PublishBookSummaryConfig:
     if len(echo_values) < SUMMARY_HEADING_LINE_COUNT or not echo_values[
         0
     ].startswith("# "):
@@ -185,18 +241,23 @@ def _parse_publish_book(
 def _resolve_summary_source_paths(
     repo_root: Path,
     publish_book_script: Path,
+    generate_grammar_script: Path,
     publish_book_source_paths: list[Path],
 ) -> list[Path] | None:
     if publish_book_source_paths:
         return publish_book_source_paths
 
-    if publish_book_script.exists():
+    if generate_grammar_script.exists():
+        logger.warning(
+            "Couldn't parse Summary of the Grammar source chapters from swift-book/bin/generate-grammar; using fallback chapter list.",
+        )
+    elif publish_book_script.exists():
         logger.warning(
             "Couldn't parse Summary of the Grammar source chapters from swift-book/bin/publish-book; using fallback chapter list.",
         )
     else:
         logger.warning(
-            "swift-book/bin/publish-book is missing; using fallback chapter list for Summary of the Grammar.",
+            "swift-book/bin/generate-grammar and swift-book/bin/publish-book are missing; using fallback chapter list for Summary of the Grammar.",
         )
 
     fallback_paths = [

--- a/tests/test_grammar_summary.py
+++ b/tests/test_grammar_summary.py
@@ -1,0 +1,147 @@
+# Copyright 2026 Evangelos Kassos
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+
+from swift_book_pdf.grammar_summary import (
+    SUMMARY_FALLBACK_SOURCE_PATHS,
+    _generate_summary_file,
+    _parse_generate_grammar,
+    _parse_publish_book,
+)
+
+
+def test_parse_generate_grammar_reads_current_upstream_layout(
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / "swift-book"
+    script_path = repo_root / "bin" / "generate-grammar"
+    script_path.parent.mkdir(parents=True)
+    script_path.write_text(
+        """#! /bin/bash
+set -eux
+{
+\techo "# Summary of the Grammar"
+\techo
+\techo "Read the whole formal grammar."
+\techo
+\tawk -f bin/extract_grammar.awk TSPL.docc/ReferenceManual/LexicalStructure.md
+\tawk -f bin/extract_grammar.awk TSPL.docc/ReferenceManual/Types.md
+} > "$summary_chapter"
+""",
+        encoding="utf-8",
+    )
+
+    config = _parse_generate_grammar(script_path)
+
+    assert config.title == "Summary of the Grammar"
+    assert config.subtitle == "Read the whole formal grammar."
+    assert config.source_paths == [
+        str(repo_root / "TSPL.docc/ReferenceManual/LexicalStructure.md"),
+        str(repo_root / "TSPL.docc/ReferenceManual/Types.md"),
+    ]
+
+
+def test_parse_publish_book_reads_legacy_embedded_summary_block(
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / "swift-book"
+    script_path = repo_root / "bin" / "publish-book"
+    script_path.parent.mkdir(parents=True)
+    script_path.write_text(
+        """#! /bin/bash
+set -eux
+summary_chapter="TSPL.docc/ReferenceManual/SummaryOfTheGrammar.md"
+{
+\techo "# Summary of the Grammar"
+\techo
+\techo "Read the whole formal grammar."
+\techo
+\tawk -f bin/extract_grammar.awk TSPL.docc/ReferenceManual/LexicalStructure.md
+\tawk -f bin/extract_grammar.awk TSPL.docc/ReferenceManual/Types.md
+} > "$summary_chapter"
+echo "done"
+""",
+        encoding="utf-8",
+    )
+
+    config = _parse_publish_book(script_path)
+
+    assert config.title == "Summary of the Grammar"
+    assert config.subtitle == "Read the whole formal grammar."
+    assert config.source_paths == [
+        str(repo_root / "TSPL.docc/ReferenceManual/LexicalStructure.md"),
+        str(repo_root / "TSPL.docc/ReferenceManual/Types.md"),
+    ]
+
+
+def test_generate_summary_file_uses_generate_grammar_source_list(
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / "swift-book"
+    publish_book = repo_root / "bin" / "publish-book"
+    generate_grammar = repo_root / "bin" / "generate-grammar"
+    publish_book.parent.mkdir(parents=True)
+    publish_book.write_text(
+        """#! /bin/bash
+summary_chapter="TSPL.docc/ReferenceManual/SummaryOfTheGrammar.md"
+bin/generate-grammar
+""",
+        encoding="utf-8",
+    )
+    generate_grammar.write_text(
+        """#! /bin/bash
+{
+\techo "# Summary of the Grammar"
+\techo
+\techo "Read the whole formal grammar."
+\techo
+\tawk -f bin/extract_grammar.awk TSPL.docc/ReferenceManual/LexicalStructure.md
+\tawk -f bin/extract_grammar.awk TSPL.docc/ReferenceManual/Types.md
+\tawk -f bin/extract_grammar.awk TSPL.docc/ReferenceManual/Expressions.md
+\tawk -f bin/extract_grammar.awk TSPL.docc/ReferenceManual/Statements.md
+\tawk -f bin/extract_grammar.awk TSPL.docc/ReferenceManual/Declarations.md
+\tawk -f bin/extract_grammar.awk TSPL.docc/ReferenceManual/Attributes.md
+\tawk -f bin/extract_grammar.awk TSPL.docc/ReferenceManual/Patterns.md
+\tawk -f bin/extract_grammar.awk TSPL.docc/ReferenceManual/GenericParametersAndArguments.md
+} > "$summary_chapter"
+""",
+        encoding="utf-8",
+    )
+
+    for source_path in SUMMARY_FALLBACK_SOURCE_PATHS:
+        chapter_path = repo_root / source_path
+        chapter_path.parent.mkdir(parents=True, exist_ok=True)
+        title = chapter_path.stem.replace("And", " And ")
+        chapter_path.write_text(
+            f"# {title}\n\n"
+            f"> Grammar of {title}\n"
+            f"> {title.lower()} -> token\n\n",
+            encoding="utf-8",
+        )
+
+    generated_summary = _generate_summary_file(
+        repo_root,
+        tmp_path / "temp-output",
+    )
+
+    assert generated_summary is not None
+    assert generated_summary.title == "Summary of the Grammar"
+    assert generated_summary.subtitle == "Read the whole formal grammar."
+
+    summary_text = Path(generated_summary.path).read_text(encoding="utf-8")
+    assert summary_text.startswith("# Summary of the Grammar\n\n")
+    assert "Read the whole formal grammar.\n\n" in summary_text
+    assert "## LexicalStructure\n\n" in summary_text
+    assert "> Grammar of LexicalStructure\n" in summary_text


### PR DESCRIPTION
### Fixed
- Fix an issue where `Summary of the Grammar` generation could fall out of sync with the latest upstream `swift-book` repo after the summary build logic moved from `bin/publish-book` to `bin/generate-grammar`. 

The breaking change was introduced in https://github.com/swiftlang/swift-book/pull/454.