### PR TITLE
feat: --dangerously-skip-legal-notices flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Add generated Acknowledgments chapter to PDF builds.
+- Add `--dangerously-skip-legal-notices` flag to skip the generating the legal notices chapter. Omitting these notices may result in missing attribution, licensing, trademark, and non-affiliation disclosures that could be required for lawful redistribution. Do not distribute or publish this output unless you have independently verified that all applicable legal obligations remain satisfied.
 
 ## [2.3.1] - 2026-04-04
 ### Fixed

--- a/swift_book_pdf/book.py
+++ b/swift_book_pdf/book.py
@@ -105,4 +105,5 @@ def _build_table_of_contents(config: Config) -> TableOfContents:
         config.root_dir,
         config.toc_file_path,
         config.temp_dir,
+        include_notices=not config.dangerously_skip_legal_notices,
     )

--- a/swift_book_pdf/cli.py
+++ b/swift_book_pdf/cli.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Evangelos Kassos
+# Copyright 2025-2026 Evangelos Kassos
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,6 +25,15 @@ from swift_book_pdf.log import configure_logging
 from swift_book_pdf.schema import OutputFormat
 
 ConfigT = TypeVar("ConfigT", bound=Config)
+LEGAL_NOTICES_WARNING = (
+    "Generated legal notices were omitted from this build because "
+    "--dangerously-skip-legal-notices was enabled. Omitting these notices "
+    "may result in missing attribution, licensing, trademark, and "
+    "non-affiliation disclosures that could be required for lawful "
+    "redistribution. Do not distribute or publish this output unless you "
+    "have independently verified that all applicable legal obligations "
+    "remain satisfied. Proceed at your own risk."
+)
 
 
 def output_path_argument(
@@ -104,6 +113,8 @@ def run_build(
         config: ConfigT | None = None
         try:
             config = config_builder(temp, validated_output_path)
+            if config.dangerously_skip_legal_notices:
+                logger.warning(LEGAL_NOTICES_WARNING)
             builder(config)
         except ValueError as e:
             logger.error(str(e))

--- a/swift_book_pdf/cli_epub.py
+++ b/swift_book_pdf/cli_epub.py
@@ -63,6 +63,15 @@ from swift_book_pdf.schema import OutputFormat
     default=None,
     help="Include a contributor in the metadata with the specified value",
 )
+@click.option(
+    "--dangerously-skip-legal-notices",
+    is_flag=True,
+    help=(
+        "Omit the generated legal notices chapter. This may remove "
+        "attribution, licensing, trademark, and non-affiliation "
+        "disclaimers that can be required for redistribution."
+    ),
+)
 @common_options
 @version_option("Swift-Book-EPUB")
 def epub(  # noqa: PLR0913
@@ -73,6 +82,7 @@ def epub(  # noqa: PLR0913
     ibooks_version: str | None,
     publisher: str | None,
     contributor: str | None,
+    dangerously_skip_legal_notices: bool,
     input_path: str | None,
     source_ref: str | None,
     source_sha: str | None,
@@ -94,6 +104,7 @@ def epub(  # noqa: PLR0913
             contributor=contributor,
             source_ref=source_ref,
             source_sha=source_sha,
+            dangerously_skip_legal_notices=dangerously_skip_legal_notices,
         ),
         builder=build_epub,
     )

--- a/swift_book_pdf/cli_pdf.py
+++ b/swift_book_pdf/cli_pdf.py
@@ -97,6 +97,15 @@ DEFAULT_TYPESETS = 4
 )
 @click.option("--dark", is_flag=True, help="Render the book in dark mode")
 @click.option(
+    "--dangerously-skip-legal-notices",
+    is_flag=True,
+    help=(
+        "Omit the generated legal notices chapter. This may remove "
+        "attribution, licensing, trademark, and non-affiliation "
+        "disclaimers that can be required for redistribution."
+    ),
+)
+@click.option(
     "--gutter/--no-gutter",
     " /-G",
     required=False,
@@ -117,6 +126,7 @@ def pdf(  # noqa: PLR0913
     header_footer: str | None,
     font_size: float | None,
     dark: bool,
+    dangerously_skip_legal_notices: bool,
     gutter: bool | None,
     input_path: str | None,
     source_ref: str | None,
@@ -151,6 +161,7 @@ def pdf(  # noqa: PLR0913
             source_ref=source_ref,
             source_sha=source_sha,
             input_path=input_path,
+            dangerously_skip_legal_notices=dangerously_skip_legal_notices,
         ),
         builder=build_pdf,
     )

--- a/swift_book_pdf/config.py
+++ b/swift_book_pdf/config.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Evangelos Kassos
+# Copyright 2025-2026 Evangelos Kassos
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,13 +29,14 @@ logger = logging.getLogger(__name__)
 class Config:
     output_format: OutputFormat
 
-    def __init__(
+    def __init__(  # noqa: PLR0913
         self,
         temp_dir_path: str,
         output_path: str,
         source_ref: str | None = None,
         source_sha: str | None = None,
         input_path: str | None = None,
+        dangerously_skip_legal_notices: bool = False,
     ) -> None:
         if not shutil.which("git"):
             raise RuntimeError("Git is not installed or not in PATH.")
@@ -53,6 +54,7 @@ class Config:
         self.toc_file_path = file_paths.toc_file_path
         self.assets_dir = file_paths.assets_dir
         self.output_path = output_path
+        self.dangerously_skip_legal_notices = dangerously_skip_legal_notices
         self.original_work_copyright_year_range = (
             find_swift_book_copyright_year_range(self.root_dir)
         )
@@ -64,6 +66,10 @@ class Config:
         logger.debug(
             "Swift book copyright year range: %s",
             self.original_work_copyright_year_range,
+        )
+        logger.debug(
+            "Skip legal notices: %s",
+            self.dangerously_skip_legal_notices,
         )
 
 
@@ -79,6 +85,7 @@ class PDFConfig(Config):
         source_ref: str | None = None,
         source_sha: str | None = None,
         input_path: str | None = None,
+        dangerously_skip_legal_notices: bool = False,
     ) -> None:
         super().__init__(
             temp_dir_path,
@@ -86,6 +93,7 @@ class PDFConfig(Config):
             source_ref=source_ref,
             source_sha=source_sha,
             input_path=input_path,
+            dangerously_skip_legal_notices=dangerously_skip_legal_notices,
         )
         self.font_config = font_config
         self.doc_config = doc_config
@@ -110,6 +118,7 @@ class EPUBConfig(Config):
         contributor: str | None = None,
         source_ref: str | None = None,
         source_sha: str | None = None,
+        dangerously_skip_legal_notices: bool = False,
     ) -> None:
         super().__init__(
             temp_dir_path,
@@ -117,6 +126,7 @@ class EPUBConfig(Config):
             source_ref=source_ref,
             source_sha=source_sha,
             input_path=input_path,
+            dangerously_skip_legal_notices=dangerously_skip_legal_notices,
         )
         self.export_cover_image = export_cover_image
         self.cover_footer_line = cover_footer_line

--- a/swift_book_pdf/epub/builder.py
+++ b/swift_book_pdf/epub/builder.py
@@ -94,7 +94,11 @@ class EPUBBuilder:
             else DEFAULT_BOOK_TITLE
         )
         parts = self._build_parts()
-        notices = self._build_notices_document()
+        notices = (
+            None
+            if self.config.dangerously_skip_legal_notices
+            else self._build_notices_document()
+        )
 
         writer.write_container_file(workspace)
         writer.write_static_files(workspace)
@@ -140,11 +144,12 @@ class EPUBBuilder:
                     ),
                 )
 
-        writer.write_text(
-            workspace,
-            notices.href,
-            renderer.render_notices_page(notices),
-        )
+        if notices is not None:
+            writer.write_text(
+                workspace,
+                notices.href,
+                renderer.render_notices_page(notices),
+            )
         writer.copy_image_assets(workspace, image_assets)
         writer.write_nav_file(workspace, cover_document, parts, notices)
         writer.write_toc_ncx_file(
@@ -257,7 +262,7 @@ class EPUBBuilder:
         self,
         cover: DocumentEntry | None,
         parts: list[PartEntry],
-        notices: DocumentEntry,
+        notices: DocumentEntry | None,
     ) -> list[DocumentEntry]:
         documents: list[DocumentEntry] = []
         if cover is not None:
@@ -273,7 +278,8 @@ class EPUBBuilder:
                 )
             )
             documents.extend(part.children)
-        documents.append(notices)
+        if notices is not None:
+            documents.append(notices)
         return documents
 
     def _parse_toc_sections(self) -> list[tuple[str, list[str]]]:

--- a/swift_book_pdf/epub/package.py
+++ b/swift_book_pdf/epub/package.py
@@ -170,9 +170,17 @@ class EPUBPackageWriter:
         workspace: Path,
         cover: DocumentEntry | None,
         parts: list[PartEntry],
-        notices: DocumentEntry,
+        notices: DocumentEntry | None,
     ) -> None:
-        reader_start_href = parts[0].href if parts else notices.href
+        reader_start_href = (
+            parts[0].href
+            if parts
+            else notices.href
+            if notices is not None
+            else cover.href
+            if cover is not None
+            else NAV_DOC_FILE_NAME
+        )
         reader_start_relative_href = relative_href(
             NAV_DOC_FILE_NAME, reader_start_href
         )
@@ -181,7 +189,6 @@ class EPUBPackageWriter:
             if cover is not None
             else None
         )
-        notices_relative_href = relative_href(NAV_DOC_FILE_NAME, notices.href)
         items = []
         if cover is not None:
             items.append(
@@ -206,11 +213,12 @@ class EPUBPackageWriter:
                 "          </ol>\n"
                 "        </li>"
             )
-        items.append(
-            "        <li>\n"
-            f'          <a href="{html.escape(relative_href(NAV_DOC_FILE_NAME, notices.href))}">{html.escape(notices.title)}</a>\n'
-            "        </li>"
-        )
+        if notices is not None:
+            items.append(
+                "        <li>\n"
+                f'          <a href="{html.escape(relative_href(NAV_DOC_FILE_NAME, notices.href))}">{html.escape(notices.title)}</a>\n'
+                "        </li>"
+            )
         self.write_text(
             workspace,
             NAV_DOC_FILE_NAME,
@@ -263,11 +271,18 @@ class EPUBPackageWriter:
             + html.escape(parts[0].title if parts else DEFAULT_BOOK_TITLE)
             + """</a>
         </li>
-        <li>
+"""
+            + (
+                """        <li>
           <a epub:type="acknowledgements" href=\""""
-            + html.escape(notices_relative_href)
-            + """\">Acknowledgments</a>
+                + html.escape(relative_href(NAV_DOC_FILE_NAME, notices.href))
+                + """\">Acknowledgments</a>
         </li>
+"""
+                if notices is not None
+                else ""
+            )
+            + """
         </ol>
       </nav>
     </section>
@@ -281,7 +296,7 @@ class EPUBPackageWriter:
         workspace: Path,
         cover: DocumentEntry | None,
         parts: list[PartEntry],
-        notices: DocumentEntry,
+        notices: DocumentEntry | None,
         book_title: str,
     ) -> None:
         part_navpoints: list[str] = []
@@ -301,12 +316,13 @@ class EPUBPackageWriter:
                 [(child.title, child.href) for child in part.children],
             )
             part_navpoints.append(part_navpoint)
-        notices_navpoint, _ = _build_ncx_navpoint_tree(
-            navpoint_index,
-            notices.title,
-            notices.href,
-        )
-        part_navpoints.append(notices_navpoint)
+        if notices is not None:
+            notices_navpoint, _ = _build_ncx_navpoint_tree(
+                navpoint_index,
+                notices.title,
+                notices.href,
+            )
+            part_navpoints.append(notices_navpoint)
         self.write_text(
             workspace,
             NCX_FILE_NAME,

--- a/swift_book_pdf/toc.py
+++ b/swift_book_pdf/toc.py
@@ -38,6 +38,7 @@ class TableOfContents:
         root_dir: str,
         tspl_file_path: str,
         temp_dir: str,
+        include_notices: bool = True,
     ) -> None:
         self.tspl_file_path = tspl_file_path
         self.target_directories = [
@@ -51,7 +52,12 @@ class TableOfContents:
             self.file_content = file.readlines()
 
         self.doc_tags = extract_doc_tags(self.file_content)
-        self.pdf_doc_tags = [*self.doc_tags, NOTICES_DOC_TAG]
+        self.include_notices = include_notices
+        self.pdf_doc_tags = (
+            [*self.doc_tags, NOTICES_DOC_TAG]
+            if include_notices
+            else [*self.doc_tags]
+        )
         self.chapter_metadata = generate_chapter_metadata(
             root_dir,
             self.target_directories,
@@ -64,18 +70,21 @@ class TableOfContents:
                 self.chapter_metadata,
             ),
         )
-        self.chapter_metadata[NOTICES_DOC_TAG.lower()] = (
-            build_notices_chapter_metadata()
-        )
+        if include_notices:
+            self.chapter_metadata[NOTICES_DOC_TAG.lower()] = (
+                build_notices_chapter_metadata()
+            )
 
     def generate_toc_latex(
         self,
         converter: LaTeXConverter,
     ) -> tuple[str, str | None]:
-        processed_lines = remove_directives(
-            self.file_content
-            + build_notices_toc_lines(include_section_heading=True)
+        notices_lines = (
+            build_notices_toc_lines(include_section_heading=True)
+            if self.include_notices
+            else []
         )
+        processed_lines = remove_directives(self.file_content + notices_lines)
         processed_lines = replace_chapter_href_with_toc_item(
             processed_lines,
             self.chapter_metadata,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,6 +16,7 @@ import logging
 from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import Mock
 
@@ -23,7 +24,7 @@ import click
 import pytest
 from click.testing import CliRunner, Result
 
-from swift_book_pdf import cli_epub, cli_pdf
+from swift_book_pdf import cli, cli_epub, cli_pdf
 
 PDF_TYPESSETS = 2
 PDF_FONT_SIZE = 10.5
@@ -79,7 +80,13 @@ def stub_pdf_font_config(monkeypatch: pytest.MonkeyPatch) -> Mock:
     [
         pytest.param(
             cli_pdf.pdf,
-            ("--mode", "--paper", "--typesets", "--main"),
+            (
+                "--mode",
+                "--paper",
+                "--typesets",
+                "--main",
+                "--dangerously-skip-legal-notices",
+            ),
             ("--export-cover-image", "--cover-footer-line"),
             id="pdf-help",
         ),
@@ -91,6 +98,7 @@ def stub_pdf_font_config(monkeypatch: pytest.MonkeyPatch) -> Mock:
                 "--override-version",
                 "--ibooks-version",
                 "--publisher",
+                "--dangerously-skip-legal-notices",
             ),
             ("--mode", "--paper", "--typesets"),
             id="epub-help",
@@ -120,7 +128,7 @@ def test_pdf_command_builds_pdf_config_and_calls_pdf_builder(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    fake_config = object()
+    fake_config = SimpleNamespace(dangerously_skip_legal_notices=True)
     font_config = stub_pdf_font_config(monkeypatch)
     pdf_config = Mock(return_value=fake_config)
     build_pdf = Mock()
@@ -152,6 +160,7 @@ def test_pdf_command_builds_pdf_config_and_calls_pdf_builder(
             "--font-size",
             str(PDF_FONT_SIZE),
             "--dark",
+            "--dangerously-skip-legal-notices",
             "--no-gutter",
             "--input-path",
             "./swift-book",
@@ -174,8 +183,10 @@ def test_pdf_command_builds_pdf_config_and_calls_pdf_builder(
     assert args[3].gutter is False
     assert args[3].font_size == PDF_FONT_SIZE
     assert kwargs["input_path"] == str(tmp_path / "swift-book")
+    assert kwargs["dangerously_skip_legal_notices"] is True
     assert kwargs["source_ref"] == "swift-6.2-branch"
     assert kwargs["source_sha"] == "abc123"
+    assert cli.LEGAL_NOTICES_WARNING in result.output
     build_pdf.assert_called_once_with(fake_config)
 
 
@@ -184,7 +195,7 @@ def test_epub_command_builds_epub_config_and_calls_epub_builder(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    fake_config = object()
+    fake_config = SimpleNamespace(dangerously_skip_legal_notices=True)
     epub_config = Mock(return_value=fake_config)
     build_epub = Mock()
     monkeypatch.setattr(cli_epub, "EPUBConfig", epub_config)
@@ -207,6 +218,7 @@ def test_epub_command_builds_epub_config_and_calls_epub_builder(
             "Swift.org",
             "--contributor",
             "Open Source Contributors",
+            "--dangerously-skip-legal-notices",
             "--input-path",
             "./swift-book",
             "--source-ref",
@@ -227,8 +239,10 @@ def test_epub_command_builds_epub_config_and_calls_epub_builder(
     assert kwargs["ibooks_version"] == "1.1"
     assert kwargs["publisher"] == "Swift.org"
     assert kwargs["contributor"] == "Open Source Contributors"
+    assert kwargs["dangerously_skip_legal_notices"] is True
     assert kwargs["source_ref"] == "swift-6.2-branch"
     assert kwargs["source_sha"] == "abc123"
+    assert cli.LEGAL_NOTICES_WARNING in result.output
     build_epub.assert_called_once_with(fake_config)
 
 
@@ -265,7 +279,7 @@ def test_directory_output_defaults_to_format_extension(
     tmp_path: Path,
     scenario: DirectoryOutputScenario,
 ) -> None:
-    fake_config = object()
+    fake_config = SimpleNamespace(dangerously_skip_legal_notices=False)
     config_mock = Mock(return_value=fake_config)
     if scenario.module is cli_pdf:
         stub_pdf_font_config(monkeypatch)

--- a/tests/test_epub_package.py
+++ b/tests/test_epub_package.py
@@ -18,6 +18,7 @@ from typing import cast
 
 from swift_book_pdf.config import EPUBConfig
 from swift_book_pdf.epub.package import EPUBPackageWriter
+from swift_book_pdf.schema import DocumentEntry
 
 
 def test_content_opf_includes_ibooks_version_metadata_when_configured(
@@ -80,3 +81,43 @@ def test_content_opf_omits_ibooks_version_metadata_by_default(
     )
 
     assert 'property="ibooks:version"' not in content_opf
+
+
+def test_nav_and_ncx_omit_acknowledgments_when_notices_are_skipped(
+    tmp_path: Path,
+) -> None:
+    config = cast(
+        EPUBConfig,
+        SimpleNamespace(
+            temp_dir=str(tmp_path),
+            output_path=str(tmp_path / "swift_book.epub"),
+            publisher=None,
+            contributor=None,
+            ibooks_version=None,
+        ),
+    )
+    writer = EPUBPackageWriter(config)
+    workspace = writer.prepare_workspace()
+    cover = DocumentEntry(
+        key="cover",
+        title="Cover",
+        subtitle=None,
+        href="cover.xhtml",
+        directory=None,
+    )
+
+    writer.write_nav_file(workspace, cover, [], None)
+    writer.write_toc_ncx_file(
+        workspace,
+        cover,
+        [],
+        None,
+        "The Swift Programming Language",
+    )
+
+    nav = (workspace / "OEBPS" / "toc.xhtml").read_text(encoding="utf-8")
+    ncx = (workspace / "OEBPS" / "toc.ncx").read_text(encoding="utf-8")
+
+    assert "Acknowledgments" not in nav
+    assert 'epub:type="acknowledgements"' not in nav
+    assert "Acknowledgments" not in ncx

--- a/tests/test_notices.py
+++ b/tests/test_notices.py
@@ -79,6 +79,22 @@ def test_pdf_notices_toc_lines_include_section_heading_only_when_requested() -> 
     ]
 
 
+def test_pdf_toc_can_skip_notices_chapter(
+    tmp_path: Path,
+) -> None:
+    toc_path = _create_minimal_swift_book_checkout(tmp_path)
+
+    toc = TableOfContents(
+        str(toc_path.parent),
+        str(toc_path),
+        str(tmp_path / "temp"),
+        include_notices=False,
+    )
+
+    assert NOTICES_DOC_TAG not in toc.pdf_doc_tags
+    assert NOTICES_DOC_KEY not in toc.chapter_metadata
+
+
 def test_render_notices_uses_detected_year_range_without_process_text() -> (
     None
 ):


### PR DESCRIPTION
## CLI
### New Features
- Add `--dangerously-skip-legal-notices` flag to skip the generating the legal notices chapter. Omitting these notices may result in missing attribution, licensing, trademark, and non-affiliation disclosures that could be required for lawful redistribution. Do not distribute or publish this output unless you have independently verified that all applicable legal obligations remain satisfied.