### PR TITLE
feat: scalable icons with font size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add generated Acknowledgments chapter to PDF builds.
 - Add `--dangerously-skip-legal-notices` flag to skip the generating the legal notices chapter. Omitting these notices may result in missing attribution, licensing, trademark, and non-affiliation disclosures that could be required for lawful redistribution. Do not distribute or publish this output unless you have independently verified that all applicable legal obligations remain satisfied.
 
+### Changed
+- Make the chapter icon in the generated PDF table of contents scale with the configured font size.
+
 ## [2.3.1] - 2026-04-04
 ### Fixed
 - Fix an issue where `Summary of the Grammar` generation could fall out of sync with the latest upstream `swift-book` repo after the summary build logic moved from `bin/publish-book` to `bin/generate-grammar`.

--- a/swift_book_pdf/contents.py
+++ b/swift_book_pdf/contents.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Evangelos Kassos
+# Copyright 2025-2026 Evangelos Kassos
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
 import re
 
 from swift_book_pdf.schema import Appearance, ChapterMetadata, RenderingMode
+
+CHAPTER_ICON_WIDTH_EM = 0.8
 
 
 def remove_directives(file_content: list[str]) -> list[str]:
@@ -84,6 +86,12 @@ def replace_chapter_href_with_toc_item(
     :return: A list of lines with the chapter references replaced
     """
     updated_lines: list[str] = []
+    icon_name = (
+        f"chapter-icon{'~dark' if appearance == Appearance.DARK else ''}.png"
+    )
+    icon_markup = (
+        rf"\includegraphics[width={CHAPTER_ICON_WIDTH_EM}em]{{{icon_name}}}"
+    )
 
     match mode:
         case RenderingMode.DIGITAL:
@@ -97,7 +105,7 @@ def replace_chapter_href_with_toc_item(
                     chapter_metadata.get(key, ChapterMetadata()).subtitle_line
                     or ""
                 )
-                return rf"\needspace{{2\baselineskip}}\item[{{\includegraphics[width=0.1in]{{chapter-icon{'~dark' if appearance == Appearance.DARK else ''}.png}}}}] \nameref{{{key}}} \\ {subtitle}"
+                return rf"\needspace{{2\baselineskip}}\item[{{{icon_markup}}}] \nameref{{{key}}} \\ {subtitle}"
 
         case RenderingMode.PRINT:
             pattern = re.compile(
@@ -110,7 +118,7 @@ def replace_chapter_href_with_toc_item(
                     chapter_metadata.get(key, ChapterMetadata()).subtitle_line
                     or ""
                 )
-                return rf"\needspace{{2\baselineskip}}\item[{{\includegraphics[width=0.1in]{{chapter-icon{'~dark' if appearance == Appearance.DARK else ''}.png}}}}] \nameref{{{key}}} {{\textcolor{{aside_border}}{{\hrulefill}}}} \pageref{{{key}}} \\ {subtitle}"
+                return rf"\needspace{{2\baselineskip}}\item[{{{icon_markup}}}] \nameref{{{key}}} {{\textcolor{{aside_border}}{{\hrulefill}}}} \pageref{{{key}}} \\ {subtitle}"
 
         case _:
             raise ValueError("Invalid rendering mode specified.")

--- a/tests/test_contents.py
+++ b/tests/test_contents.py
@@ -29,9 +29,7 @@ def test_toc_chapter_icon_uses_em_based_width_in_digital_mode() -> None:
         Appearance.LIGHT,
     )
 
-    assert (
-        r"\includegraphics[width=0.8em]{chapter-icon.png}" in rendered[0]
-    )
+    assert r"\includegraphics[width=0.8em]{chapter-icon.png}" in rendered[0]
     assert "0.1in" not in rendered[0]
 
 
@@ -49,6 +47,5 @@ def test_toc_chapter_icon_uses_dark_asset_in_print_mode() -> None:
     )
 
     assert (
-        r"\includegraphics[width=0.8em]{chapter-icon~dark.png}"
-        in rendered[0]
+        r"\includegraphics[width=0.8em]{chapter-icon~dark.png}" in rendered[0]
     )

--- a/tests/test_contents.py
+++ b/tests/test_contents.py
@@ -1,0 +1,54 @@
+# Copyright 2026 Evangelos Kassos
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from swift_book_pdf.contents import replace_chapter_href_with_toc_item
+from swift_book_pdf.schema import Appearance, ChapterMetadata, RenderingMode
+
+
+def test_toc_chapter_icon_uses_em_based_width_in_digital_mode() -> None:
+    lines = [r"\item \ParagraphStyle{\fallbackrefdigital{guidedtour}}"]
+    metadata = {
+        "guidedtour": ChapterMetadata(subtitle_line="A quick start."),
+    }
+
+    rendered = replace_chapter_href_with_toc_item(
+        lines,
+        metadata,
+        RenderingMode.DIGITAL,
+        Appearance.LIGHT,
+    )
+
+    assert (
+        r"\includegraphics[width=0.8em]{chapter-icon.png}" in rendered[0]
+    )
+    assert "0.1in" not in rendered[0]
+
+
+def test_toc_chapter_icon_uses_dark_asset_in_print_mode() -> None:
+    lines = [r"\item \ParagraphStyle{\fallbackrefbook{guidedtour}}"]
+    metadata = {
+        "guidedtour": ChapterMetadata(subtitle_line="A quick start."),
+    }
+
+    rendered = replace_chapter_href_with_toc_item(
+        lines,
+        metadata,
+        RenderingMode.PRINT,
+        Appearance.DARK,
+    )
+
+    assert (
+        r"\includegraphics[width=0.8em]{chapter-icon~dark.png}"
+        in rendered[0]
+    )


### PR DESCRIPTION
## Markdown to LaTeX Conversion
### Updates & Improvements
- Make the chapter icon in the generated PDF table of contents scale with the configured font size.