### PR TITLE
feat: override version in pdf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add new `--override-version` option to `swift-book-pdf`.
+- Require PDF and EPUB builds to resolve the Swift version either from the table of contents or from an explicit override.
 
 ## [2.4.1] - 2026-04-10
 ### Fixed

--- a/src/swift_book_pdf/book.py
+++ b/src/swift_book_pdf/book.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from tqdm import trange
 
 from swift_book_pdf.config import Config, EPUBConfig, PDFConfig
+from swift_book_pdf.contents import resolve_version_info
 from swift_book_pdf.epub import EPUBBuilder
 from swift_book_pdf.latex import LaTeXConverter
 from swift_book_pdf.notices import NOTICES_DOC_KEY, render_notices_latex
@@ -40,6 +41,7 @@ class PDFBookBuilder:
         latex_file_path: str,
     ) -> None:
         latex = generate_preamble(self.config)
+        self._version_info()
         # TODO: Use the version to generate a cover page
         toc_latex, _ = self.toc.generate_toc_latex(converter=converter)
         latex += toc_latex + "\n"
@@ -89,6 +91,11 @@ class PDFBookBuilder:
             logger.error(
                 f"Failed to save PDF to {self.config.output_path}: {e}"
             )
+
+    def _version_info(self) -> str:
+        return resolve_version_info(
+            self.toc.file_content, self.config.override_version
+        )
 
 
 def build_pdf(config: PDFConfig) -> None:

--- a/src/swift_book_pdf/cli_pdf.py
+++ b/src/swift_book_pdf/cli_pdf.py
@@ -58,6 +58,12 @@ DEFAULT_TYPESETS = 4
     show_default=str(DEFAULT_TYPESETS),
 )
 @click.option(
+    "--override-version",
+    type=str,
+    default=None,
+    help='Override the version number. Include "beta" for beta versions.',
+)
+@click.option(
     "--main",
     type=str,
     default=None,
@@ -119,6 +125,7 @@ def pdf(  # noqa: PLR0913
     mode: str,
     paper: str,
     typesets: int,
+    override_version: str | None,
     main: str | None,
     mono: str | None,
     unicode: list[str],
@@ -158,6 +165,7 @@ def pdf(  # noqa: PLR0913
             validated_output_path,
             font_config,
             doc_config,
+            override_version=override_version,
             source_ref=source_ref,
             source_sha=source_sha,
             input_path=input_path,

--- a/src/swift_book_pdf/config.py
+++ b/src/swift_book_pdf/config.py
@@ -82,6 +82,7 @@ class PDFConfig(Config):
         output_path: str,
         font_config: FontConfig,
         doc_config: DocConfig,
+        override_version: str | None = None,
         source_ref: str | None = None,
         source_sha: str | None = None,
         input_path: str | None = None,
@@ -97,9 +98,11 @@ class PDFConfig(Config):
         )
         self.font_config = font_config
         self.doc_config = doc_config
+        self.override_version = override_version
         logger.debug(f"Output format: {self.output_format}")
         logger.debug(f"Font configuration: {self.font_config}")
         logger.debug(f"Document configuration: {self.doc_config}")
+        logger.debug(f"Version override: {override_version}")
 
 
 class EPUBConfig(Config):

--- a/src/swift_book_pdf/contents.py
+++ b/src/swift_book_pdf/contents.py
@@ -71,6 +71,25 @@ def replace_and_extract_version(
     return updated_lines, version_info
 
 
+def resolve_version_info(
+    file_content: list[str],
+    override_version: str | None = None,
+) -> str:
+    if override_version is not None:
+        normalized_override_version = override_version.strip()
+        if normalized_override_version:
+            return normalized_override_version
+
+    _, version_info = replace_and_extract_version(file_content)
+    if version_info is not None:
+        return version_info
+
+    raise ValueError(
+        "Couldn't determine the Swift version by parsing the table of "
+        "contents. Please provide --override-version."
+    )
+
+
 def replace_chapter_href_with_toc_item(
     file_content: list[str],
     chapter_metadata: dict[str, ChapterMetadata],

--- a/src/swift_book_pdf/epub/builder.py
+++ b/src/swift_book_pdf/epub/builder.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING
 from swift_book_pdf.blocks import parse_blocks
 from swift_book_pdf.contents import (
     remove_directives,
-    replace_and_extract_version,
+    resolve_version_info,
 )
 from swift_book_pdf.files import get_swift_book_repository_revision
 from swift_book_pdf.markdown_helpers import (
@@ -169,12 +169,10 @@ class EPUBBuilder:
         writer.package_epub(workspace)
         logger.info(f"EPUB saved to {self.config.output_path}")
 
-    def _extract_version_info(self) -> str | None:
-        _, version_info = replace_and_extract_version(self.toc.file_content)
-        return version_info
-
-    def _version_info(self) -> str | None:
-        return self.config.override_version or self._extract_version_info()
+    def _version_info(self) -> str:
+        return resolve_version_info(
+            self.toc.file_content, self.config.override_version
+        )
 
     def _build_parts(self) -> list[PartEntry]:
         parts: list[PartEntry] = []

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -84,6 +84,7 @@ def stub_pdf_font_config(monkeypatch: pytest.MonkeyPatch) -> Mock:
                 "--mode",
                 "--paper",
                 "--typesets",
+                "--override-version",
                 "--main",
                 "--dangerously-skip-legal-notices",
             ),
@@ -147,6 +148,8 @@ def test_pdf_command_builds_pdf_config_and_calls_pdf_builder(
             "a4",
             "--typesets",
             str(PDF_TYPESSETS),
+            "--override-version",
+            "6.2 beta",
             "--main",
             "New York",
             "--mono",
@@ -182,6 +185,7 @@ def test_pdf_command_builds_pdf_config_and_calls_pdf_builder(
     assert args[3].appearance.value == "dark"
     assert args[3].gutter is False
     assert args[3].font_size == PDF_FONT_SIZE
+    assert kwargs["override_version"] == "6.2 beta"
     assert kwargs["input_path"] == str(tmp_path / "swift-book")
     assert kwargs["dangerously_skip_legal_notices"] is True
     assert kwargs["source_ref"] == "swift-6.2-branch"

--- a/tests/test_contents.py
+++ b/tests/test_contents.py
@@ -12,7 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from swift_book_pdf.contents import replace_chapter_href_with_toc_item
+import pytest
+
+from swift_book_pdf.contents import (
+    replace_chapter_href_with_toc_item,
+    resolve_version_info,
+)
 from swift_book_pdf.schema import (
     Appearance,
     ChapterMetadata,
@@ -53,3 +58,33 @@ def test_toc_chapter_icon_uses_dark_asset_in_print_mode() -> None:
     assert (
         r"\includegraphics[width=0.8em]{chapter-icon~dark.png}" in rendered[0]
     )
+
+
+def test_resolve_version_info_prefers_override_version() -> None:
+    assert (
+        resolve_version_info(
+            ["# The Swift Programming Language (6.1)\n"],
+            "6.2 beta",
+        )
+        == "6.2 beta"
+    )
+
+
+def test_resolve_version_info_extracts_from_toc_when_available() -> None:
+    assert (
+        resolve_version_info(["# The Swift Programming Language (6.2 beta)\n"])
+        == "6.2 beta"
+    )
+
+
+def test_resolve_version_info_requires_override_when_toc_has_no_version() -> (
+    None
+):
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Couldn't determine the Swift version by parsing the table of "
+            "contents. Please provide --override-version."
+        ),
+    ):
+        resolve_version_info(["# The Swift Programming Language\n"])


### PR DESCRIPTION
### Added
- Add new `--override-version` option to `swift-book-pdf`.
- Require PDF and EPUB builds to resolve the Swift version either from the table of contents or from an explicit override.