### PR TITLE
fix: color text for apache license

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix an issue where the Apache License text in the generated Acknowledgments chapter could be rendered with the wrong text color in dark mode.
 
 ## [2.4.1] - 2026-04-10
 ### Fixed

--- a/src/swift_book_pdf/preamble.py
+++ b/src/swift_book_pdf/preamble.py
@@ -703,7 +703,7 @@ $keep_whole_box_patch
   breakable,
   whole on next page if possible,
   listing options={
-    basicstyle=\monoFontWithFallback{$mono_font}\fontsize{${font_size_minted}pt}{${font_size_minted_leading}pt}\selectfont,
+    basicstyle=\color{text}\monoFontWithFallback{$mono_font}\fontsize{${font_size_minted}pt}{${font_size_minted_leading}pt}\selectfont,
     breaklines=true,
     breakatwhitespace=false,
     columns=fullflexible,


### PR DESCRIPTION
Fix an issue where the Apache License text in the generated Acknowledgments chapter could be rendered with the wrong text color in dark mode.