### PR TITLE
fix: module escape in code blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix an issue where the generated Acknowledgments chapter may be missing the `swift-docc-render` copyright notice.
 - Fix an issue where the Apache License text in the generated Acknowledgments chapter could be rendered with the wrong text color in dark mode.
+- Fix an issue where percent signs in code blocks could be escaped incorrectly in generated PDF versions.
 
 ## [2.4.1] - 2026-04-10
 ### Fixed

--- a/src/swift_book_pdf/latex_helpers.py
+++ b/src/swift_book_pdf/latex_helpers.py
@@ -316,8 +316,7 @@ def convert_nested_block(block: Block, mode: RenderingMode) -> str:
             r"\begin{swiftstyledbox}" + "\n"
         )
         for line in block.lines:
-            line2 = line.replace("%", r"\%")
-            out += override_characters(line2) + "\n"
+            out += override_characters(line) + "\n"
         out += r"\end{swiftstyledbox}" + "\n"
         return out
     # fallback
@@ -432,10 +431,7 @@ def _convert_header_like_block(
 
 def _convert_code_block(block: CodeBlock) -> list[str]:
     output = ["\\parskip=0pt\n" + r"\begin{flushleft}\begin{swiftstyledbox}"]
-    output.extend(
-        override_characters(line.replace("%", r"\%"), True)
-        for line in block.lines
-    )
+    output.extend(override_characters(line, True) for line in block.lines)
     output.append(r"\end{swiftstyledbox}" + "\n\\end{flushleft}\n")
     return output
 

--- a/tests/test_code_blocks.py
+++ b/tests/test_code_blocks.py
@@ -1,0 +1,37 @@
+# Copyright 2026 Evangelos Kassos
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from swift_book_pdf.latex_helpers import (
+    _convert_code_block,
+    convert_nested_block,
+)
+from swift_book_pdf.schema import CodeBlock, RenderingMode
+
+
+def test_convert_code_block_preserves_percent_for_minted() -> None:
+    block = CodeBlock(lines=["-9 % 4 // equals -1"])
+
+    rendered = "\n".join(_convert_code_block(block))
+
+    assert "-9 % 4 // equals -1" in rendered
+    assert r"\%" not in rendered
+
+
+def test_convert_nested_code_block_preserves_percent_for_minted() -> None:
+    block = CodeBlock(lines=["-9 % 4 // equals -1"])
+
+    rendered = convert_nested_block(block, RenderingMode.PRINT)
+
+    assert "-9 % 4 // equals -1" in rendered
+    assert r"\%" not in rendered


### PR DESCRIPTION
Fix an issue where percent signs in code blocks could be escaped incorrectly in generated PDF versions.