### PR TITLE
chore: git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# 215ffe1: chore: add more ruff linting rules (#59)
+215ffe157175069d2e64540a147e4214be9efd88

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix an issue where the generated Acknowledgments chapter may be missing the `swift-docc-render` copyright notice.
 - Fix an issue where the Apache License text in the generated Acknowledgments chapter could be rendered with the wrong text color in dark mode.
 
+### Internal
+- Add `.git-blame-ignore-revs` file to hide the repository-wide Ruff linting commit from `git blame`.
+
 ## [2.4.1] - 2026-04-10
 ### Fixed
 - Fix an issue where the generated Acknowledgments chapter may be missing the `swift-docc-render` NOTICE content.


### PR DESCRIPTION
Add `.git-blame-ignore-revs` file to hide the repository-wide Ruff linting commit from `git blame`.