### PR TITLE
fix: color text for apache license

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Fix an issue where PDF editions could be missing the bundled Swift logo assets.
+- Fix an issue where the Apache License text in the generated Acknowledgments chapter could be rendered with the wrong text color in dark mode.
 
 ### [2.5.0] - 2026-04-11
 ### Added

--- a/src/swift_book_pdf/preamble.py
+++ b/src/swift_book_pdf/preamble.py
@@ -719,7 +719,7 @@ $keep_whole_box_patch
   boxsep=0pt,
   before skip={\dimexpr\ifprecededbybox${spacing_box_before_preceded}\else${spacing_box_before}\fi},
   after skip=0in,
-  before upper=\color{text},
+  colupper=text,
   after app={\global\precededbyboxtrue\global\precededbysectionfalse\global\precededbyparagraphfalse\global\precededbynotefalse\global\AtPageTopfalse},
 }
 


### PR DESCRIPTION
Fix an issue where the Apache License text in the generated Acknowledgments chapter could be rendered with the wrong text color in dark mode.