### PR TITLE
fix: asterisk in math mode in notices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix an issue where PDF editions could be missing the bundled Swift logo assets.
 - Fix an issue where the Apache License text in the generated Acknowledgments chapter could be rendered with the wrong text color in dark mode.
+- Fix an issue where asterisks in the Apache License text were incorrectly rendered in math mode in the generated Acknowledgments chapter.
 
 ### [2.5.0] - 2026-04-11
 ### Added

--- a/src/swift_book_pdf/preamble.py
+++ b/src/swift_book_pdf/preamble.py
@@ -698,17 +698,18 @@ $keep_whole_box_patch
 }
 
 \newtcblisting{plainlistingbox}{
-  listing engine=listings,
   listing only,
   breakable,
   whole on next page if possible,
-  listing options={
-    basicstyle=\color{text}\monoFontWithFallback{$mono_font}\fontsize{${font_size_minted}pt}{${font_size_minted_leading}pt}\selectfont,
+  minted language=text,
+  minted options={
+    fontsize=\customsmall,
     breaklines=true,
-    breakatwhitespace=false,
-    columns=fullflexible,
-    keepspaces=true,
-    showstringspaces=false,
+    breakanywhere=true,
+    autogobble=true,
+    tabsize=2,
+    frame=none,
+    framesep=0pt,
   },
   colback=code_background,
   colframe=code_border,


### PR DESCRIPTION
Fix an issue where asterisks in the Apache License text were incorrectly rendered in math mode in the generated Acknowledgments chapter.