### PR TITLE
fix(epub): convert double hyphens to en dashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix an issue where double hyphens in generated EPUB prose were not converted to en dashes.
 
 ## [2.5.1] - 2026-04-12
 ### Fixed

--- a/src/swift_book_pdf/epub/render.py
+++ b/src/swift_book_pdf/epub/render.py
@@ -838,7 +838,8 @@ def _replace_markdown_links(
 
 
 def _normalize_prose_punctuation(text: str) -> str:
-    return re.sub(r"\s*---\s*", "—", text)
+    text = re.sub(r"\s*---\s*", "\u2014", text)
+    return re.sub(r"--", "\u2013", text)
 
 
 def _image_display_width(path: Path, file_name: str) -> float | None:

--- a/tests/test_epub_render.py
+++ b/tests/test_epub_render.py
@@ -1,0 +1,27 @@
+# Copyright 2026 Evangelos Kassos
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from swift_book_pdf.epub.render import _normalize_prose_punctuation
+
+
+def test_normalize_prose_punctuation_converts_triple_hyphen_to_em_dash() -> (
+    None
+):
+    assert _normalize_prose_punctuation("before --- after") == "before—after"
+
+
+def test_normalize_prose_punctuation_converts_double_hyphen_to_en_dash() -> (
+    None
+):
+    assert _normalize_prose_punctuation("Swift 5.9--6.0") == "Swift 5.9–6.0"

--- a/tests/test_epub_render.py
+++ b/tests/test_epub_render.py
@@ -24,4 +24,6 @@ def test_normalize_prose_punctuation_converts_triple_hyphen_to_em_dash() -> (
 def test_normalize_prose_punctuation_converts_double_hyphen_to_en_dash() -> (
     None
 ):
-    assert _normalize_prose_punctuation("Swift 5.9--6.0") == "Swift 5.9–6.0"
+    assert (
+        _normalize_prose_punctuation("Swift 5.9--6.0") == "Swift 5.9\u20136.0"
+    )


### PR DESCRIPTION
Fix an issue where double hyphens in generated EPUB prose were not converted to en dashes.