### PR TITLE
fix(epub): preserve inline code spans that look like markdown links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fix an issue where inline code spans that resemble Markdown links could be rendered as placeholder tokens in generated EPUB output.
+
 ## [2.5.2] - 2026-04-13
 ### Fixed
 - Fix an issue where double hyphens in generated EPUB prose were not converted to en dashes.

--- a/src/swift_book_pdf/epub/render.py
+++ b/src/swift_book_pdf/epub/render.py
@@ -793,48 +793,84 @@ def _replace_markdown_links(
     index = 0
 
     while index < len(text):
-        label_start = text.find("[", index)
-        if label_start == -1:
-            output.append(text[index:])
-            break
-
-        output.append(text[index:label_start])
-        label_end = text.find("]", label_start + 1)
-        if (
-            label_end == -1
-            or label_end + 1 >= len(text)
-            or text[label_end + 1] != "("
-        ):
-            output.append(text[label_start])
-            index = label_start + 1
+        fenced_segment = _consume_inline_code_fence(text, index)
+        if fenced_segment is not None:
+            output.append(fenced_segment[0])
+            index = fenced_segment[1]
             continue
 
-        href_start = label_end + 2
-        href_end = href_start
-        depth = 1
-        while href_end < len(text):
-            character = text[href_end]
-            if character == "(":
-                depth += 1
-            elif character == ")":
-                depth -= 1
-                if depth == 0:
-                    break
-            href_end += 1
-
-        if href_end >= len(text) or depth != 0:
-            output.append(text[label_start])
-            index = label_start + 1
+        if text[index] != "[":
+            output.append(text[index])
+            index += 1
             continue
 
-        output.append(
-            render(
-                text[label_start + 1 : label_end], text[href_start:href_end]
-            )
-        )
-        index = href_end + 1
+        parsed_link = _parse_markdown_link(text, index)
+        if parsed_link is None:
+            output.append(text[index])
+            index += 1
+            continue
+
+        label, href, next_index = parsed_link
+        output.append(render(label, href))
+        index = next_index
 
     return "".join(output)
+
+
+def _consume_inline_code_fence(
+    text: str, start_index: int
+) -> tuple[str, int] | None:
+    if text[start_index] != "`":
+        return None
+
+    fence_end = start_index
+    while fence_end < len(text) and text[fence_end] == "`":
+        fence_end += 1
+
+    fence = text[start_index:fence_end]
+    closing_index = text.find(fence, fence_end)
+    if closing_index == -1:
+        return text[start_index:], len(text)
+
+    return text[start_index : closing_index + len(fence)], (
+        closing_index + len(fence)
+    )
+
+
+def _parse_markdown_link(
+    text: str, start_index: int
+) -> tuple[str, str, int] | None:
+    label_end = text.find("]", start_index + 1)
+    if label_end == -1 or label_end + 1 >= len(text):
+        return None
+    if text[label_end + 1] != "(":
+        return None
+
+    href_start = label_end + 2
+    href_end = _find_balanced_href_end(text, href_start)
+    if href_end is None:
+        return None
+
+    return (
+        text[start_index + 1 : label_end],
+        text[href_start:href_end],
+        href_end + 1,
+    )
+
+
+def _find_balanced_href_end(text: str, start_index: int) -> int | None:
+    href_end = start_index
+    depth = 1
+    while href_end < len(text):
+        character = text[href_end]
+        if character == "(":
+            depth += 1
+        elif character == ")":
+            depth -= 1
+            if depth == 0:
+                return href_end
+        href_end += 1
+    return None
 
 
 def _normalize_prose_punctuation(text: str) -> str:

--- a/tests/test_epub_render.py
+++ b/tests/test_epub_render.py
@@ -12,7 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from swift_book_pdf.epub.render import _normalize_prose_punctuation
+from swift_book_pdf.epub.render import (
+    LinkResolver,
+    _normalize_prose_punctuation,
+    _render_inline,
+)
 
 
 def test_normalize_prose_punctuation_converts_triple_hyphen_to_em_dash() -> (
@@ -26,4 +30,33 @@ def test_normalize_prose_punctuation_converts_double_hyphen_to_en_dash() -> (
 ):
     assert (
         _normalize_prose_punctuation("Swift 5.9--6.0") == "Swift 5.9\u20136.0"
+    )
+
+
+def test_render_inline_keeps_markdown_like_code_spans_literal() -> None:
+    rendered = _render_inline(
+        (
+            "Alternatively, you can create an empty array of a certain type "
+            "using explicit initializer syntax, by writing the element type "
+            "in square brackets followed by parentheses---for example, "
+            "`[Int]()` in the following:"
+        ),
+        "CollectionTypes.xhtml",
+        LinkResolver([]),
+    )
+
+    assert "@@INLINE" not in rendered
+    assert '<code class="inline-code">[Int]()</code>' in rendered
+
+
+def test_render_inline_supports_code_inside_markdown_link_labels() -> None:
+    rendered = _render_inline(
+        "Read [`Array`](https://example.com) first.",
+        "CollectionTypes.xhtml",
+        LinkResolver([]),
+    )
+
+    assert (
+        '<a href="https://example.com">'
+        '<code class="inline-code">Array</code></a>' in rendered
     )


### PR DESCRIPTION
## Fixed
- Fix an issue where inline code spans that resemble Markdown links could be rendered as placeholder tokens in generated EPUB output.

Resolves #118 