### PR TITLE
feat(epub): add --base-cover-image support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,18 @@ build/
 # OS-specific files
 .DS_Store
 Thumbs.db
+
+# PDF assets not needed in version control
+src/swift_book_pdf/assets/
+!src/swift_book_pdf/assets/chapter-icon.png
+!src/swift_book_pdf/assets/chapter-icon~dark.png
+!src/swift_book_pdf/assets/Swift_logo_color.png
+!src/swift_book_pdf/assets/Swift_logo_white.png
+
+# EPUB assets not needed in version control
+!src/swift_book_pdf/assets/Swift_logo_color_epub.png
+src/swift_book_pdf/assets/epub_reference/
+!src/swift_book_pdf/assets/epub_reference/cover.png
+!src/swift_book_pdf/assets/epub_reference/cover-beta.png
+!src/swift_book_pdf/assets/epub_reference/epub.css
+!src/swift_book_pdf/assets/epub_reference/pygments.css

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add new `--base-cover-image` option to swift-book-epub to let EPUB builds use a provided cover template image instead of deriving one from the version string and the bundled assets.
 
 ### Fixed
 - Fix an issue where inline code spans that resemble Markdown links could be rendered as placeholder tokens in generated EPUB output.

--- a/src/swift_book_pdf/cli_epub.py
+++ b/src/swift_book_pdf/cli_epub.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from pathlib import Path
+
 import click
 
 from swift_book_pdf.book import build_epub
@@ -32,6 +34,19 @@ from swift_book_pdf.schema import OutputFormat
     "-e",
     is_flag=True,
     help="Also save the generated cover image as a separate file in the output directory",
+)
+@click.option(
+    "--base-cover-image",
+    type=click.Path(
+        exists=True,
+        dir_okay=False,
+        path_type=Path,
+    ),
+    default=None,
+    help=(
+        "Use the specified base cover image file instead of selecting one "
+        "from the version string."
+    ),
 )
 @click.option(
     "--cover-footer-line",
@@ -77,6 +92,7 @@ from swift_book_pdf.schema import OutputFormat
 def epub(  # noqa: PLR0913
     output_path: str,
     export_cover_image: bool,
+    base_cover_image: Path | None,
     cover_footer_line: str | None,
     override_version: str | None,
     ibooks_version: str | None,
@@ -97,6 +113,7 @@ def epub(  # noqa: PLR0913
             validated_output_path,
             input_path=input_path,
             export_cover_image=export_cover_image,
+            base_cover_image=base_cover_image,
             cover_footer_line=cover_footer_line,
             override_version=override_version,
             ibooks_version=ibooks_version,

--- a/src/swift_book_pdf/config.py
+++ b/src/swift_book_pdf/config.py
@@ -14,6 +14,7 @@
 
 import logging
 import shutil
+from pathlib import Path
 
 from swift_book_pdf.doc import DocConfig
 from swift_book_pdf.files import (
@@ -114,6 +115,7 @@ class EPUBConfig(Config):
         output_path: str,
         input_path: str | None = None,
         export_cover_image: bool = False,
+        base_cover_image: Path | None = None,
         cover_footer_line: str | None = None,
         override_version: str | None = None,
         ibooks_version: str | None = None,
@@ -132,6 +134,7 @@ class EPUBConfig(Config):
             dangerously_skip_legal_notices=dangerously_skip_legal_notices,
         )
         self.export_cover_image = export_cover_image
+        self.base_cover_image = base_cover_image
         self.cover_footer_line = cover_footer_line
         self.override_version = override_version
         self.ibooks_version = ibooks_version
@@ -141,6 +144,7 @@ class EPUBConfig(Config):
         logger.debug(
             f"Save generated cover image as separate file: {export_cover_image}"
         )
+        logger.debug(f"Base cover image: {base_cover_image}")
         logger.debug(f"Cover footer line: {cover_footer_line}")
         logger.debug(f"Version override: {override_version}")
         logger.debug(f"Apple Books version metadata: {ibooks_version}")

--- a/src/swift_book_pdf/epub/helpers.py
+++ b/src/swift_book_pdf/epub/helpers.py
@@ -111,7 +111,12 @@ def cover_edition_text(version_info: str | None) -> str | None:
     return f"Swift {normalized_version} Edition"
 
 
-def cover_template_path(version_info: str | None) -> Path:
+def cover_template_path(
+    version_info: str | None,
+    base_cover_image: Path | None = None,
+) -> Path:
+    if base_cover_image is not None:
+        return base_cover_image
     if version_info is not None and "beta" in version_info.lower():
         return COVER_BETA_TEMPLATE_PATH
     return COVER_TEMPLATE_PATH

--- a/src/swift_book_pdf/epub/package.py
+++ b/src/swift_book_pdf/epub/package.py
@@ -114,7 +114,10 @@ class EPUBPackageWriter:
     def write_cover_asset(
         self, workspace: Path, version_info: str | None
     ) -> None:
-        template_path = cover_template_path(version_info)
+        template_path = cover_template_path(
+            version_info,
+            self.config.base_cover_image,
+        )
         if not template_path.exists():
             logger.warning(
                 "Couldn't find cover template %s; skipping cover.",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -95,6 +95,7 @@ def stub_pdf_font_config(monkeypatch: pytest.MonkeyPatch) -> Mock:
             cli_epub.epub,
             (
                 "--export-cover-image",
+                "--base-cover-image",
                 "--cover-footer-line",
                 "--override-version",
                 "--ibooks-version",
@@ -207,11 +208,15 @@ def test_epub_command_builds_epub_config_and_calls_epub_builder(
 
     output_dir = tmp_path / "dist"
     output_dir.mkdir()
+    cover_path = tmp_path / "custom-cover.png"
+    cover_path.write_bytes(b"png")
     result = runner.invoke(
         cli_epub.epub,
         [
             str(output_dir),
             "--export-cover-image",
+            "--base-cover-image",
+            str(cover_path),
             "--cover-footer-line",
             "Beta",
             "--override-version",
@@ -238,6 +243,7 @@ def test_epub_command_builds_epub_config_and_calls_epub_builder(
     assert args[1] == str(output_dir / "swift_book.epub")
     assert kwargs["input_path"] == str(tmp_path / "swift-book")
     assert kwargs["export_cover_image"] is True
+    assert kwargs["base_cover_image"] == cover_path
     assert kwargs["cover_footer_line"] == "Beta"
     assert kwargs["override_version"] == "6.2 beta"
     assert kwargs["ibooks_version"] == "1.1"

--- a/tests/test_epub_helpers.py
+++ b/tests/test_epub_helpers.py
@@ -1,0 +1,26 @@
+# Copyright 2026 Evangelos Kassos
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+
+from swift_book_pdf.epub.helpers import cover_template_path
+
+
+def test_cover_template_path_prefers_explicit_base_cover_image(
+    tmp_path: Path,
+) -> None:
+    base_cover_image = tmp_path / "cover-custom.png"
+    assert (
+        cover_template_path("6.2 beta", base_cover_image) == base_cover_image
+    )


### PR DESCRIPTION
### Added
- Add new `--base-cover-image` option to swift-book-epub to let EPUB builds use a provided cover template image instead of deriving one from the version string and the bundled assets.