### PR TITLE
feat:(epub): add cover banner, other style improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Add new `--base-cover-image` option to swift-book-epub to let EPUB builds use a provided cover template image instead of deriving one from the version string and the bundled assets.
+- Add new `--base-cover-image` option to `swift-book-epub` to let EPUB builds use a provided cover template image instead of deriving one from the version string and the bundled assets.
+- Add new `--cover-banner-text` and `--cover-banner-color` options to `swift-book-epub` to add a custom banner to the inner cover, with automatic `Beta` banner support for beta editions.
+
+### Changed
+- Redesign the generated EPUB inner cover to use SVG-based layout and typography, improving cover composition, accessibility text, and support for optional footer lines and banners presented in the outer cover.
 
 ### Fixed
 - Fix an issue where inline code spans that resemble Markdown links could be rendered as placeholder tokens in generated EPUB output.

--- a/src/swift_book_pdf/assets/epub_reference/epub.css
+++ b/src/swift_book_pdf/assets/epub_reference/epub.css
@@ -48,82 +48,88 @@ img.align-center {
 
 body.coverpage {
   margin: 0;
+  padding: 0;
   background: #fff;
-  text-align: center;
+  height: 100vh;
+  width: 100vw;
+  overflow: hidden;
   break-after: always;
   page-break-after: always;
-  height: 100vh;
-  overflow: hidden;
   display: -webkit-box;
   display: -webkit-flex;
   display: flex;
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
-  -webkit-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  justify-content: flex-start;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-box-align: stretch;
+  -webkit-align-items: stretch;
+  align-items: stretch;
 }
 
-.cover-shell {
-  margin: 0 auto;
-  width: 100%;
-  max-width: 820px;
-  padding: 64px 40px 48px;
-  box-sizing: border-box;
-  break-inside: avoid;
-  page-break-inside: avoid;
-  -webkit-box-flex: 0;
-  -webkit-flex: 0 0 auto;
-  flex: 0 0 auto;
-}
-
-.cover-logo-wrap {
-  margin: 0 0 40px;
-}
-
-.cover-logo {
+.cover-canvas-svg {
   display: block;
-  width: 116px;
-  height: auto;
-  margin: 0 auto;
+  width: 100%;
+  height: 100%;
 }
 
-.titleContainer {
-  break-inside: avoid;
-  page-break-inside: avoid;
+.cover-canvas-svg .cover-title-text,
+.cover-canvas-svg .cover-subtitle-text {
+  fill: #2b2b2b;
 }
 
-.coverpage h1,
-.coverpage h2 {
-  margin: 0;
-  color: #2b2b2b;
-  font-family: "SF Compact Display", "SF Pro Display", "SF Compact", "SF Pro",
-    "Helvetica Neue", "Helvetica", "Arial", "Segoe UI", "Liberation Sans",
-    "DejaVu Sans", sans-serif;
-  font-style: normal;
-  text-align: center;
-  hyphens: none;
-  break-inside: avoid;
-  page-break-inside: avoid;
+.cover-canvas-svg .cover-footer-text {
+  fill: #6f6f6f;
 }
 
-.coverpage h1 {
-  font-size: 52px;
-  font-weight: 400;
-  line-height: 0.96;
-  margin-bottom: 2px;
+.cover-canvas-svg .cover-svg-logo-dark {
+  display: none;
 }
 
-.coverpage h2 {
-  font-size: 24px;
-  font-weight: 400;
-  line-height: 1.15;
+@media (prefers-color-scheme: dark) {
+  body.coverpage {
+    background: #1c1c1e;
+  }
+
+  .cover-canvas-svg .cover-title-text,
+  .cover-canvas-svg .cover-subtitle-text {
+    fill: #f2f2f2;
+  }
+
+  .cover-canvas-svg .cover-footer-text {
+    fill: #a0a0a0;
+  }
+
+  .cover-canvas-svg .cover-svg-logo-light {
+    display: none;
+  }
+
+  .cover-canvas-svg .cover-svg-logo-dark {
+    display: inline;
+  }
 }
 
-#title3 {
-  margin-top: 64px;
+ul.simple,
+ol.arabic.simple {
+  padding-inline-start: 1.5em;
+  -webkit-padding-start: 1.5em;
+}
+
+ul.simple > li,
+ol.arabic.simple > li {
+  padding-inline-start: 0.25em;
+  -webkit-padding-start: 0.25em;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .section h1 {

--- a/src/swift_book_pdf/cli_epub.py
+++ b/src/swift_book_pdf/cli_epub.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
 from pathlib import Path
 
 import click
@@ -25,6 +26,20 @@ from swift_book_pdf.cli import (
 )
 from swift_book_pdf.config import EPUBConfig
 from swift_book_pdf.schema import OutputFormat
+
+_HEX_COLOR_RE = re.compile(r"^#(?:[0-9a-fA-F]{3}){1,2}$")
+
+
+def _validate_hex_color(
+    _ctx: click.Context, _param: click.Parameter, value: str | None
+) -> str | None:
+    if value is None:
+        return None
+    if not _HEX_COLOR_RE.match(value):
+        raise click.BadParameter(
+            f"{value!r} is not a valid hex color (expected #RGB or #RRGGBB)."
+        )
+    return value
 
 
 @click.command(name="swift-book-epub")
@@ -53,6 +68,25 @@ from swift_book_pdf.schema import OutputFormat
     type=str,
     default=None,
     help="Include the specified text in the cover image footer",
+)
+@click.option(
+    "--cover-banner-text",
+    type=str,
+    default=None,
+    help=(
+        "Add a banner at the top of the inner cover with the given text. "
+        'When the version is beta and this flag is omitted, "beta" is used.'
+    ),
+)
+@click.option(
+    "--cover-banner-color",
+    type=str,
+    default=None,
+    callback=_validate_hex_color,
+    help=(
+        "Background color of the inner-cover banner as a hex string "
+        "(e.g. #a5aeb0). Defaults to #a5aeb0."
+    ),
 )
 @click.option(
     "--override-version",
@@ -94,6 +128,8 @@ def epub(  # noqa: PLR0913
     export_cover_image: bool,
     base_cover_image: Path | None,
     cover_footer_line: str | None,
+    cover_banner_text: str | None,
+    cover_banner_color: str | None,
     override_version: str | None,
     ibooks_version: str | None,
     publisher: str | None,
@@ -115,6 +151,8 @@ def epub(  # noqa: PLR0913
             export_cover_image=export_cover_image,
             base_cover_image=base_cover_image,
             cover_footer_line=cover_footer_line,
+            cover_banner_text=cover_banner_text,
+            cover_banner_color=cover_banner_color,
             override_version=override_version,
             ibooks_version=ibooks_version,
             publisher=publisher,

--- a/src/swift_book_pdf/config.py
+++ b/src/swift_book_pdf/config.py
@@ -117,6 +117,8 @@ class EPUBConfig(Config):
         export_cover_image: bool = False,
         base_cover_image: Path | None = None,
         cover_footer_line: str | None = None,
+        cover_banner_text: str | None = None,
+        cover_banner_color: str | None = None,
         override_version: str | None = None,
         ibooks_version: str | None = None,
         publisher: str | None = None,
@@ -136,6 +138,8 @@ class EPUBConfig(Config):
         self.export_cover_image = export_cover_image
         self.base_cover_image = base_cover_image
         self.cover_footer_line = cover_footer_line
+        self.cover_banner_text = cover_banner_text
+        self.cover_banner_color = cover_banner_color
         self.override_version = override_version
         self.ibooks_version = ibooks_version
         self.publisher = publisher
@@ -146,6 +150,8 @@ class EPUBConfig(Config):
         )
         logger.debug(f"Base cover image: {base_cover_image}")
         logger.debug(f"Cover footer line: {cover_footer_line}")
+        logger.debug(f"Cover banner text: {cover_banner_text}")
+        logger.debug(f"Cover banner color: {cover_banner_color}")
         logger.debug(f"Version override: {override_version}")
         logger.debug(f"Apple Books version metadata: {ibooks_version}")
         logger.debug(f"Publisher: {publisher}")

--- a/src/swift_book_pdf/epub/builder.py
+++ b/src/swift_book_pdf/epub/builder.py
@@ -56,6 +56,7 @@ from .helpers import (
     anchor_for_heading,
     build_publication_identifier,
     make_unique_anchor,
+    resolve_cover_banner,
 )
 from .package import EPUBPackageWriter
 from .render import EPUBRenderer, LinkResolver, extract_grammar_terms
@@ -119,11 +120,21 @@ class EPUBBuilder:
         image_assets: dict[str, ImageAsset] = {}
 
         if cover_document is not None:
+            cover_banner = resolve_cover_banner(
+                self.config.cover_banner_text,
+                self.config.cover_banner_color,
+                version_info,
+                self.config.base_cover_image,
+            )
             writer.write_text(
                 workspace,
                 cover_document.href,
                 renderer.render_cover_page(
-                    cover_document, book_title, version_info
+                    cover_document,
+                    book_title,
+                    version_info,
+                    cover_banner=cover_banner,
+                    cover_footer_line=self.config.cover_footer_line,
                 ),
             )
 

--- a/src/swift_book_pdf/epub/helpers.py
+++ b/src/swift_book_pdf/epub/helpers.py
@@ -122,6 +122,33 @@ def cover_template_path(
     return COVER_TEMPLATE_PATH
 
 
+BETA_BANNER_DEFAULT_COLOR = "#a5aeb0"
+
+
+def cover_uses_beta_style(
+    version_info: str | None,
+    base_cover_image: Path | None = None,
+) -> bool:
+    del base_cover_image
+    return version_info is not None and "beta" in version_info.lower()
+
+
+def resolve_cover_banner(
+    banner_text: str | None,
+    banner_color: str | None,
+    version_info: str | None,
+    base_cover_image: Path | None = None,
+) -> tuple[str, str] | None:
+    text = banner_text.strip() if banner_text else None
+    is_beta = cover_uses_beta_style(version_info, base_cover_image)
+    if text is None and is_beta:
+        text = "Beta"
+    if not text:
+        return None
+    color = banner_color or BETA_BANNER_DEFAULT_COLOR
+    return text, color
+
+
 def build_publication_identifier(
     version_info: str | None,
     source_revision: str | None,

--- a/src/swift_book_pdf/epub/render.py
+++ b/src/swift_book_pdf/epub/render.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import html
 import logging
 import re
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -148,13 +149,17 @@ class EPUBRenderer:
             f"<h1>{html.escape(part.title)}</h1>\n"
             "</div>\n"
         )
-        return self._wrap_xhtml_document(part.title, part.href, body)
+        return self._wrap_xhtml_document(
+            part.title, part.href, body, body_class="part-body"
+        )
 
     def render_cover_page(
         self,
         document: DocumentEntry,
         book_title: str,
         version_info: str | None,
+        cover_banner: tuple[str, str] | None = None,
+        cover_footer_line: str | None = None,
     ) -> str:
         edition_text = cover_edition_text(version_info)
         logo_light_href = html.escape(
@@ -163,31 +168,120 @@ class EPUBRenderer:
         logo_dark_href = html.escape(
             relative_href(document.href, EPUB_COVER_LOGO_DARK_FILE_NAME)
         )
-        subtitle_html = (
-            f'      <h2 id="title3">{html.escape(edition_text)}</h2>\n'
-            if edition_text
-            else ""
+        css_href = html.escape(
+            relative_href(document.href, "_static/epub.css")
         )
+        svg_font_family = (
+            "&apos;SF Compact Display&apos;, &apos;SF Pro Display&apos;, "
+            "&apos;SF Compact&apos;, &apos;SF Pro&apos;, "
+            "&apos;Helvetica Neue&apos;, Helvetica, Arial, "
+            "&apos;Segoe UI&apos;, &apos;Liberation Sans&apos;, "
+            "&apos;DejaVu Sans&apos;, sans-serif"
+        )
+
+        layers: list[str] = []
+
+        if cover_banner is not None:
+            banner_text, banner_color = cover_banner
+            layers.append(
+                f'        <rect x="0" y="0" width="1440" height="206" '
+                f'fill="{html.escape(banner_color)}"/>\n'
+                f'        <text x="720" y="155" text-anchor="middle" '
+                f'font-family="{svg_font_family}" font-weight="400" '
+                f'font-size="150" font-kerning="normal" fill="#ffffff">'
+                f"{html.escape(banner_text)}</text>\n"
+            )
+
+        layers.append(
+            f'        <image class="cover-svg-logo cover-svg-logo-light" '
+            f'x="453.5" y="321" width="533" height="533" '
+            f'xlink:href="{logo_light_href}" href="{logo_light_href}" '
+            f'preserveAspectRatio="xMidYMid meet"/>\n'
+            f'        <image class="cover-svg-logo cover-svg-logo-dark" '
+            f'x="453.5" y="321" width="533" height="533" '
+            f'xlink:href="{logo_dark_href}" href="{logo_dark_href}" '
+            f'preserveAspectRatio="xMidYMid meet"/>\n'
+        )
+
+        layers.append(
+            _render_cover_title_line(
+                "The Swift",
+                top_y=968.84,
+                horizontal_scale=1.06,
+                letter_spacing=-4.4,
+                style=CoverTitleStyle(
+                    font_family=svg_font_family,
+                    font_kerning="normal",
+                ),
+            )
+        )
+        layers.append(
+            _render_cover_title_line(
+                "Programming",
+                top_y=1138.84,
+                horizontal_scale=1.04,
+                letter_spacing=0.0,
+                style=CoverTitleStyle(
+                    font_family=svg_font_family,
+                    font_kerning="auto",
+                ),
+            )
+        )
+        layers.append(
+            _render_cover_title_line(
+                "Language",
+                top_y=1308.84,
+                horizontal_scale=1.04,
+                letter_spacing=-2.64,
+                style=CoverTitleStyle(
+                    font_family=svg_font_family,
+                    font_kerning="auto",
+                ),
+            )
+        )
+
+        if edition_text:
+            layers.append(
+                f'        <text class="cover-subtitle-text" '
+                f'transform="matrix(1,0,0,0.9,720,1604.99)" x="0" y="97" '
+                f'text-anchor="middle" font-family="{svg_font_family}" '
+                f'font-weight="400" font-size="125" letter-spacing="0.2" '
+                f'font-kerning="normal" fill="#2b2b2b">'
+                f"{html.escape(edition_text)}</text>\n"
+            )
+
+        if cover_footer_line:
+            layers.append(
+                f'        <text class="cover-footer-text" x="720" y="2023" '
+                f'text-anchor="middle" font-family="{svg_font_family}" '
+                f'font-weight="400" font-size="58" font-kerning="normal" '
+                f'fill="#6f6f6f">'
+                f"{html.escape(cover_footer_line)}</text>\n"
+            )
+
+        accessible_parts: list[str] = []
+        if cover_banner is not None:
+            accessible_parts.append(cover_banner[0])
+        accessible_parts.append("The Swift Programming Language")
+        if edition_text:
+            accessible_parts.append(edition_text)
+        if cover_footer_line:
+            accessible_parts.append(cover_footer_line)
+        accessible_title = " — ".join(accessible_parts)
+
+        svg_body = "".join(layers)
         return f"""<!DOCTYPE html>
 
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops">
   <head>
     <meta charset="utf-8" />
     <title>{html.escape(book_title)}</title>
-    <link rel="stylesheet" href="{html.escape(relative_href(document.href, "_static/epub.css"))}" type="text/css" />
+    <link rel="stylesheet" href="{css_href}" type="text/css" />
   </head>
   <body class="coverpage" id="coverpage">
-    <div class="cover-shell">
-      <div class="theme-image cover-logo-wrap">
-        <img class="align-center image-light cover-logo" src="{logo_light_href}" alt="Swift logo" />
-        <img class="align-center image-dark cover-logo" src="{logo_dark_href}" alt="Swift logo" />
-      </div>
-      <div class="titleContainer">
-        <h1 id="title1a">The Swift</h1>
-        <h1 id="title1b">Programming</h1>
-        <h1 id="title1c">Language</h1>
-{subtitle_html}      </div>
-    </div>
+    <h1 class="visually-hidden">{html.escape(accessible_title)}</h1>
+    <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" class="cover-canvas-svg" viewBox="0 0 1440 2160" preserveAspectRatio="xMidYMid meet" role="img" aria-label="{html.escape(accessible_title)}">
+{svg_body}    </svg>
   </body>
 </html>
 """
@@ -227,12 +321,17 @@ class EPUBRenderer:
         return self._wrap_xhtml_document(document.title, document.href, body)
 
     def _wrap_xhtml_document(
-        self, title: str, href: str, body_html: str
+        self,
+        title: str,
+        href: str,
+        body_html: str,
+        body_class: str | None = None,
     ) -> str:
         css_href = html.escape(relative_href(href, "_static/epub.css"))
         pygments_href = html.escape(
             relative_href(href, "_static/pygments.css")
         )
+        body_attr = f' class="{html.escape(body_class)}"' if body_class else ""
         return f"""<!DOCTYPE html>
 
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops">
@@ -242,7 +341,7 @@ class EPUBRenderer:
     <link rel="stylesheet" href="{css_href}" type="text/css" />
     <link rel="stylesheet" href="{pygments_href}" type="text/css" />
   </head>
-  <body>
+  <body{body_attr}>
     <main class="book-root" role="main">
 {body_html}
     </main>
@@ -517,6 +616,40 @@ class EPUBRenderer:
         if count == 1:
             return f"grammar_{fragment}"
         return f"grammar_{fragment}_{count}"
+
+
+COVER_TITLE_FONT_SIZE = 176
+COVER_TITLE_ASCENT = 137
+COVER_TITLE_VERTICAL_SCALE = 0.9
+COVER_TITLE_CENTER_X = 720
+
+
+@dataclass(frozen=True)
+class CoverTitleStyle:
+    font_family: str
+    font_kerning: str
+
+
+def _render_cover_title_line(
+    text: str,
+    top_y: float,
+    horizontal_scale: float,
+    letter_spacing: float,
+    style: CoverTitleStyle,
+) -> str:
+    matrix = (
+        f"matrix({horizontal_scale},0,0,{COVER_TITLE_VERTICAL_SCALE},"
+        f"{COVER_TITLE_CENTER_X},{top_y})"
+    )
+    return (
+        f'        <text class="cover-title-text" transform="{matrix}" '
+        f'x="0" y="{COVER_TITLE_ASCENT}" text-anchor="middle" '
+        f'font-family="{style.font_family}" font-weight="400" '
+        f'font-size="{COVER_TITLE_FONT_SIZE}" '
+        f'letter-spacing="{letter_spacing}" '
+        f'font-kerning="{style.font_kerning}" fill="#2b2b2b">'
+        f"{html.escape(text)}</text>\n"
+    )
 
 
 def _heading_level(block: Block) -> int | None:

--- a/tests/test_epub_helpers.py
+++ b/tests/test_epub_helpers.py
@@ -14,7 +14,10 @@
 
 from pathlib import Path
 
-from swift_book_pdf.epub.helpers import cover_template_path
+from swift_book_pdf.epub.helpers import (
+    cover_template_path,
+    resolve_cover_banner,
+)
 
 
 def test_cover_template_path_prefers_explicit_base_cover_image(
@@ -23,4 +26,25 @@ def test_cover_template_path_prefers_explicit_base_cover_image(
     base_cover_image = tmp_path / "cover-custom.png"
     assert (
         cover_template_path("6.2 beta", base_cover_image) == base_cover_image
+    )
+
+
+def test_resolve_cover_banner_uses_explicit_beta_base_cover_image() -> None:
+    assert resolve_cover_banner(None, None, "6.2 beta", None) == (
+        "Beta",
+        "#a5aeb0",
+    )
+
+
+def test_resolve_cover_banner_keeps_version_based_beta_banner_for_explicit_cover_path(
+    tmp_path: Path,
+) -> None:
+    assert resolve_cover_banner(
+        None,
+        None,
+        "6.2 beta",
+        tmp_path / "cover-custom.png",
+    ) == (
+        "Beta",
+        "#a5aeb0",
     )


### PR DESCRIPTION
### Added
- Add new `--cover-banner-text` and `--cover-banner-color` options to `swift-book-epub` to add a custom banner to the inner cover, with automatic `Beta` banner support for beta editions.

### Changed
- Redesign the generated EPUB inner cover to use SVG-based layout and typography, improving cover composition, accessibility text, and support for optional footer lines and banners presented in the outer cover.