### PR TITLE
fix(epub): mark cover document as svg in OPF manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fix an issue where inline code spans that resemble Markdown links could be rendered as placeholder tokens in generated EPUB output.
+- Fix an issue where generated EPUB package metadata did not mark the SVG-based cover document with the required `svg` property.
 
 ## [2.5.2] - 2026-04-13
 ### Fixed

--- a/src/swift_book_pdf/epub/package.py
+++ b/src/swift_book_pdf/epub/package.py
@@ -43,6 +43,7 @@ from .constants import (
     COVER_TEXT_X,
     COVER_TEXT_Y,
     DEFAULT_BOOK_TITLE,
+    EPUB_COVER_DOC_FILE_NAME,
     EPUB_COVER_LOGO_DARK_FILE_NAME,
     EPUB_COVER_LOGO_FILE_NAME,
     EPUB_IDENTIFIER_ID,
@@ -380,6 +381,11 @@ class EPUBPackageWriter:
                     item_id=f"epub-doc-{index}",
                     href=document.href,
                     media_type="application/xhtml+xml",
+                    properties=(
+                        "svg"
+                        if document.href == EPUB_COVER_DOC_FILE_NAME
+                        else None
+                    ),
                 )
             )
 

--- a/tests/test_epub_package.py
+++ b/tests/test_epub_package.py
@@ -83,6 +83,48 @@ def test_content_opf_omits_ibooks_version_metadata_by_default(
     assert 'property="ibooks:version"' not in content_opf
 
 
+def test_content_opf_marks_cover_document_as_svg(
+    tmp_path: Path,
+) -> None:
+    config = cast(
+        EPUBConfig,
+        SimpleNamespace(
+            temp_dir=str(tmp_path),
+            output_path=str(tmp_path / "swift_book.epub"),
+            publisher=None,
+            contributor=None,
+            ibooks_version=None,
+        ),
+    )
+    writer = EPUBPackageWriter(config)
+    workspace = writer.prepare_workspace()
+
+    writer.write_content_opf_file(
+        workspace,
+        "The Swift Programming Language",
+        [
+            DocumentEntry(
+                key="cover",
+                title="Cover",
+                subtitle=None,
+                href="cover.xhtml",
+                directory=None,
+            )
+        ],
+        {},
+        "urn:uuid:test-book",
+    )
+
+    content_opf = (workspace / "OEBPS" / "content.opf").read_text(
+        encoding="utf-8"
+    )
+
+    assert (
+        '<item id="epub-doc-0" href="cover.xhtml" '
+        'media-type="application/xhtml+xml" properties="svg" />' in content_opf
+    )
+
+
 def test_nav_and_ncx_omit_acknowledgments_when_notices_are_skipped(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
### Fixed
- Fix an issue where generated EPUB package metadata did not mark the SVG-based cover document with the required `svg` property.