### PR TITLE
feat(epub): custom publication identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add new `--base-cover-image` option to `swift-book-epub` to let EPUB builds use a provided cover template image instead of deriving one from the version string and the bundled assets.
 - Add new `--cover-banner-text` and `--cover-banner-color` options to `swift-book-epub` to add a custom banner to the inner cover, with automatic `Beta` banner support for beta editions.
+- Add new `--publication-identifier-seed` option to `swift-book-epub` to override the pre-hash seed used when deriving the EPUB publication identifier.
 
 ### Changed
 - Redesign the generated EPUB inner cover to use SVG-based layout and typography, improving cover composition, accessibility text, and support for optional footer lines and banners presented in the outer cover.

--- a/src/swift_book_pdf/cli_epub.py
+++ b/src/swift_book_pdf/cli_epub.py
@@ -95,6 +95,15 @@ def _validate_hex_color(
     help='Override the version number. Include "beta" for beta versions.',
 )
 @click.option(
+    "--publication-identifier-seed",
+    type=str,
+    default=None,
+    help=(
+        "Override the pre-hash seed used for the EPUB publication identifier. "
+        "This bypasses the default source-revision or version-derived seed."
+    ),
+)
+@click.option(
     "--ibooks-version",
     type=str,
     default=None,
@@ -131,6 +140,7 @@ def epub(  # noqa: PLR0913
     cover_banner_text: str | None,
     cover_banner_color: str | None,
     override_version: str | None,
+    publication_identifier_seed: str | None,
     ibooks_version: str | None,
     publisher: str | None,
     contributor: str | None,
@@ -154,6 +164,7 @@ def epub(  # noqa: PLR0913
             cover_banner_text=cover_banner_text,
             cover_banner_color=cover_banner_color,
             override_version=override_version,
+            publication_identifier_seed=publication_identifier_seed,
             ibooks_version=ibooks_version,
             publisher=publisher,
             contributor=contributor,

--- a/src/swift_book_pdf/config.py
+++ b/src/swift_book_pdf/config.py
@@ -120,6 +120,7 @@ class EPUBConfig(Config):
         cover_banner_text: str | None = None,
         cover_banner_color: str | None = None,
         override_version: str | None = None,
+        publication_identifier_seed: str | None = None,
         ibooks_version: str | None = None,
         publisher: str | None = None,
         contributor: str | None = None,
@@ -141,6 +142,7 @@ class EPUBConfig(Config):
         self.cover_banner_text = cover_banner_text
         self.cover_banner_color = cover_banner_color
         self.override_version = override_version
+        self.publication_identifier_seed = publication_identifier_seed
         self.ibooks_version = ibooks_version
         self.publisher = publisher
         self.contributor = contributor
@@ -153,6 +155,10 @@ class EPUBConfig(Config):
         logger.debug(f"Cover banner text: {cover_banner_text}")
         logger.debug(f"Cover banner color: {cover_banner_color}")
         logger.debug(f"Version override: {override_version}")
+        logger.debug(
+            "Publication identifier seed override: %s",
+            publication_identifier_seed,
+        )
         logger.debug(f"Apple Books version metadata: {ibooks_version}")
         logger.debug(f"Publisher: {publisher}")
         logger.debug(f"Contributor: {contributor}")

--- a/src/swift_book_pdf/epub/builder.py
+++ b/src/swift_book_pdf/epub/builder.py
@@ -87,6 +87,7 @@ class EPUBBuilder:
         publication_identifier = build_publication_identifier(
             version_info,
             source_revision,
+            self.config.publication_identifier_seed,
         )
         writer.publication_identifier = publication_identifier
         book_title = (

--- a/src/swift_book_pdf/epub/helpers.py
+++ b/src/swift_book_pdf/epub/helpers.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import html
+import logging
 import posixpath
 import re
 import uuid
@@ -25,6 +26,8 @@ from .constants import (
     COVER_TEMPLATE_PATH,
     OEBPS_DIR_NAME,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def relative_href(current_href: str, target_href: str) -> str:
@@ -152,12 +155,21 @@ def resolve_cover_banner(
 def build_publication_identifier(
     version_info: str | None,
     source_revision: str | None,
+    publication_identifier_seed: str | None = None,
 ) -> str:
-    seed = source_revision
+    seed = publication_identifier_seed
+    if seed is None:
+        seed = source_revision
     if seed is None and version_info is not None:
         normalized_version = " ".join(version_info.split())
         if normalized_version:
             seed = f"version:{normalized_version}"
     if seed is None:
+        logger.debug(
+            "EPUB publication identifier seed unavailable; generating random UUID4"
+        )
         return f"urn:uuid:{uuid.uuid4()}"
+    logger.debug(
+        f"EPUB publication identifier pre-hash seed: swift-book:{seed}"
+    )
     return f"urn:uuid:{uuid.uuid5(uuid.NAMESPACE_URL, f'swift-book:{seed}')}"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -98,6 +98,7 @@ def stub_pdf_font_config(monkeypatch: pytest.MonkeyPatch) -> Mock:
                 "--base-cover-image",
                 "--cover-footer-line",
                 "--override-version",
+                "--publication-identifier-seed",
                 "--ibooks-version",
                 "--publisher",
                 "--dangerously-skip-legal-notices",
@@ -221,6 +222,8 @@ def test_epub_command_builds_epub_config_and_calls_epub_builder(
             "Beta",
             "--override-version",
             "6.2 beta",
+            "--publication-identifier-seed",
+            "version:6.2.3",
             "--ibooks-version",
             "1.1",
             "--publisher",
@@ -246,6 +249,7 @@ def test_epub_command_builds_epub_config_and_calls_epub_builder(
     assert kwargs["base_cover_image"] == cover_path
     assert kwargs["cover_footer_line"] == "Beta"
     assert kwargs["override_version"] == "6.2 beta"
+    assert kwargs["publication_identifier_seed"] == "version:6.2.3"
     assert kwargs["ibooks_version"] == "1.1"
     assert kwargs["publisher"] == "Swift.org"
     assert kwargs["contributor"] == "Open Source Contributors"

--- a/tests/test_epub_helpers.py
+++ b/tests/test_epub_helpers.py
@@ -15,6 +15,7 @@
 from pathlib import Path
 
 from swift_book_pdf.epub.helpers import (
+    build_publication_identifier,
     cover_template_path,
     resolve_cover_banner,
 )
@@ -47,4 +48,16 @@ def test_resolve_cover_banner_keeps_version_based_beta_banner_for_explicit_cover
     ) == (
         "Beta",
         "#a5aeb0",
+    )
+
+
+def test_build_publication_identifier_prefers_explicit_seed_override() -> None:
+    expected = "urn:uuid:b984fd30-8362-53d6-9879-e2f1803a9020"
+    assert (
+        build_publication_identifier(
+            "6.2.4",
+            "2306b38fdd2235b9d7a070e342098c2e08dda90d",
+            "version:6.2.3",
+        )
+        == expected
     )


### PR DESCRIPTION
### Added 
- Add new `--publication-identifier-seed` option to `swift-book-epub` to override the pre-hash seed used when deriving the EPUB publication identifier.