### PR TITLE
fix(epub): center title pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix an issue where inline code spans that resemble Markdown links could be rendered as placeholder tokens in generated EPUB output.
 - Fix an issue where generated EPUB package metadata did not mark the SVG-based cover document with the required `svg` property.
+- Fix an issue where generated EPUB part title pages were positioned with a hardcoded top margin instead of being vertically centered within the page.
 
 ## [2.5.2] - 2026-04-13
 ### Fixed

--- a/src/swift_book_pdf/assets/epub_reference/epub.css
+++ b/src/swift_book_pdf/assets/epub_reference/epub.css
@@ -162,14 +162,38 @@ a {
   color: rgb(0 136 204 / 100%);
 }
 
+body.part-body {
+  margin: 0;
+  padding: 0;
+}
+
+body.part-body .book-root {
+  margin: 0;
+  padding: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
 .part-page {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  flex: 1 0 auto;
+  min-height: 100vh;
+  margin: 0;
+  padding: 0;
+  text-align: center;
   break-after: always;
   page-break-after: always;
 }
 
 .part-page h1 {
   font-size: 2.5em;
-  margin-top: 55%;
+  line-height: 1.25;
+  margin: 0;
+  padding: 0 0.5em;
   text-align: center;
 }
 


### PR DESCRIPTION
### Fixed 
- Fix an issue where generated EPUB part title pages were positioned with a hardcoded top margin instead of being vertically centered within the page.