### PR TITLE
Improve LaTeX dependency error handling

### DIFF
--- a/src/swift_book_pdf/pdf.py
+++ b/src/swift_book_pdf/pdf.py
@@ -208,7 +208,12 @@ class PDFConverter:
     def __init__(self, config: PDFConfig) -> None:
         lualatex_executable = shutil.which("lualatex")
         if lualatex_executable is None:
-            raise RuntimeError("lualatex is not installed or not in PATH.")
+            raise RuntimeError(
+                "LaTeX is required to generate PDFs, but 'lualatex' was not found. "
+                "Install a LaTeX distribution and make sure it is available on PATH. "
+                "Windows users can install MiKTeX, macOS users can install MacTeX, "
+                "and Linux users can install TeX Live."
+            )
         self.lualatex_executable = lualatex_executable
         check_required_latex_packages_installed()
         check_minted_runtime_compatibility()


### PR DESCRIPTION
## Summary
Improved the error message shown when LaTeX is missing during PDF generation.

## Changes
- Replaced the generic lualatex missing error with a clearer message
- Added installation guidance for Windows, macOS, and Linux
- Improved the user experience when PDF generation cannot start because LaTeX is unavailable

## Tests
- uv run pytest tests/test_cli.py
- uv run pytest

Result: 42 passed