### PR TITLE
fix(pdf): header text alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make the inner-cover banner unconditional and default its text to `RELEASE VERSION` or `BETA VERSION` based on the resolved edition; `--cover-banner-text` now overrides the label and `--cover-banner-color` defaults to the edition's accent color.
 - Refresh the trademark wording in the generated notices page and acknowledge the bundled IBM Plex fonts under the SIL Open Font License 1.1, including the full OFL text.
 
+### Fixed
+- Fix an issue where the header text in the generated PDF document could be misaligned between odd and even pages.
+
 ### Removed
 - Remove the bundled `Swift_logo_color_epub.png` asset, which is no longer referenced by the new SVG-based cover layout.
 - Remove the Swift logo from the header and footer of the generated PDF document, and remove the related `swift-logo` asset directory.

--- a/src/swift_book_pdf/pdf/latex/templates/header_footer_hero_no_gutter.tex
+++ b/src/swift_book_pdf/pdf/latex/templates/header_footer_hero_no_gutter.tex
@@ -4,7 +4,7 @@
   \fill[header_background] ([yshift=-0.5in]current page.north west)
   rectangle ([yshift=-0.9in]current page.north east);
 
-  \node[anchor=east,white] at ([yshift=-0.70in,xshift=-0.7in]current page.north east) {
+  \node[anchor=base east,white] at ([yshift=-0.70in,xshift=-0.7in]current page.north east) {
     \scalebox{1.10}[1]{\headerFontWithFallback{$header_footer_font}{LetterSpace=-3.5} \fontsize{13pt}{0pt}\selectfont \customheader}
   };
 \end{tikzpicture}%

--- a/src/swift_book_pdf/pdf/latex/templates/header_footer_hero_no_gutter.tex
+++ b/src/swift_book_pdf/pdf/latex/templates/header_footer_hero_no_gutter.tex
@@ -4,7 +4,7 @@
   \fill[header_background] ([yshift=-0.5in]current page.north west)
   rectangle ([yshift=-0.9in]current page.north east);
 
-  \node[anchor=base east,white] at ([yshift=-0.70in,xshift=-0.7in]current page.north east) {
+  \node[anchor=base east,white] at ([yshift=-0.764in,xshift=-0.7in]current page.north east) {
     \scalebox{1.10}[1]{\headerFontWithFallback{$header_footer_font}{LetterSpace=-3.5} \fontsize{13pt}{0pt}\selectfont \customheader}
   };
 \end{tikzpicture}%

--- a/src/swift_book_pdf/pdf/latex/templates/header_footer_hero_with_gutter.tex
+++ b/src/swift_book_pdf/pdf/latex/templates/header_footer_hero_with_gutter.tex
@@ -4,7 +4,7 @@
   \fill[header_background] ([yshift=-0.5in]current page.north west)
   rectangle ([yshift=-0.9in]current page.north east);
 
-  \node[anchor=base east,white] at ([yshift=-0.71in,xshift=-0.7in]current page.north east) {
+  \node[anchor=base east,white] at ([yshift=-0.764in,xshift=-0.7in]current page.north east) {
     \scalebox{1.10}[1]{\headerFontWithFallback{$header_footer_font}{LetterSpace=-3.5} \fontsize{13pt}{0pt}\selectfont \customheader}
   };
 \end{tikzpicture}%
@@ -16,7 +16,7 @@
 \fill[header_background] ([yshift=-0.5in]current page.north west)
  rectangle ([yshift=-0.9in]current page.north east);
 
-\node[anchor=base west,white] at ([yshift=-0.71in,xshift=0.7in]current page.north west) {
+\node[anchor=base west,white] at ([yshift=-0.764in,xshift=0.7in]current page.north west) {
   \scalebox{1.10}[1]{\headerFontWithFallback{$header_footer_font}{LetterSpace=-3.5} \fontsize{13pt}{0pt}\selectfont The Swift Programming Language}
 };
 \end{tikzpicture}%

--- a/src/swift_book_pdf/pdf/latex/templates/header_footer_hero_with_gutter.tex
+++ b/src/swift_book_pdf/pdf/latex/templates/header_footer_hero_with_gutter.tex
@@ -4,7 +4,7 @@
   \fill[header_background] ([yshift=-0.5in]current page.north west)
   rectangle ([yshift=-0.9in]current page.north east);
 
-  \node[anchor=east,white] at ([yshift=-0.70in,xshift=-0.7in]current page.north east) {
+  \node[anchor=base east,white] at ([yshift=-0.71in,xshift=-0.7in]current page.north east) {
     \scalebox{1.10}[1]{\headerFontWithFallback{$header_footer_font}{LetterSpace=-3.5} \fontsize{13pt}{0pt}\selectfont \customheader}
   };
 \end{tikzpicture}%
@@ -16,7 +16,7 @@
 \fill[header_background] ([yshift=-0.5in]current page.north west)
  rectangle ([yshift=-0.9in]current page.north east);
 
-\node[anchor=west,white] at ([yshift=-0.71in,xshift=0.7in]current page.north west) {
+\node[anchor=base west,white] at ([yshift=-0.71in,xshift=0.7in]current page.north west) {
   \scalebox{1.10}[1]{\headerFontWithFallback{$header_footer_font}{LetterSpace=-3.5} \fontsize{13pt}{0pt}\selectfont The Swift Programming Language}
 };
 \end{tikzpicture}%


### PR DESCRIPTION
Fix an issue where the header text in the generated PDF document could be misaligned between odd and even pages.