### PR TITLE
feat(pdf): save tex artifact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - When `--cover-footer-line` is omitted, render the `--contributor` value (if any) as a "Compiled by:" credit on the inner cover.
 - Bundle IBM Plex Sans and IBM Plex Serif with the EPUB so cover text and front matter render consistently across reading environments, regardless of host-installed fonts.
 - Add a project-owned `swift-book-swift` Pygments lexer for Swift code highlighting, derived from the Highlight.js Swift grammar and registered for both Python and minted/PDF use.
+- Add new `--save-tex` flag to `swift-book-pdf` to save the generated LaTeX source instead of compiling a PDF.
 
 ### Changed
 - Redesign generated EPUB cover artwork and rendered cover text for release and beta editions, with new templates, edition-specific colors, and adjusted version-label spacing and positioning.

--- a/src/swift_book_pdf/core/output.py
+++ b/src/swift_book_pdf/core/output.py
@@ -25,3 +25,6 @@ class OutputFormat(StrEnum):
 
     EPUB = "epub"
     """Generate an EPUB artifact."""
+
+    TEX = "tex"
+    """Generate a LaTeX source artifact."""

--- a/src/swift_book_pdf/pdf/backend.py
+++ b/src/swift_book_pdf/pdf/backend.py
@@ -52,6 +52,9 @@ class PDFBackendConfigInput:
     doc_config: PDFDocumentConfig
     """Resolved PDF document layout options."""
 
+    save_tex: bool
+    """Whether to save LaTeX source instead of compiling a PDF."""
+
     override_version: str | None
     """Optional Swift version override."""
 
@@ -66,13 +69,13 @@ class PDFEngine(Protocol):
     """Engine interface for producing a temporary PDF artifact."""
 
     def build(self, context: PDFBuildContext) -> Path:
-        """Render and compile a PDF.
+        """Render a temporary artifact.
 
         Args:
             context: Shared PDF build inputs.
 
         Returns:
-            Path to the temporary PDF artifact.
+            Path to the temporary artifact.
         """
 
 

--- a/src/swift_book_pdf/pdf/builder.py
+++ b/src/swift_book_pdf/pdf/builder.py
@@ -32,9 +32,9 @@ def build_pdf(config: PDFConfig) -> None:
 
     Raises:
         FileNotFoundError: If the selected engine does not produce the
-            expected temporary PDF.
-        RuntimeError: If the generated PDF cannot be moved to the requested
-            output path.
+            expected temporary artifact.
+        RuntimeError: If the generated artifact cannot be moved to the
+            requested output path.
     """
     toc = TableOfContents(
         config.root_dir,
@@ -43,21 +43,24 @@ def build_pdf(config: PDFConfig) -> None:
         include_notices=not config.dangerously_skip_legal_notices,
     )
     doc_config = config.doc_config
+    artifact_label = "TeX" if config.save_tex else "PDF"
     logger.info(
-        f"Creating PDF in {doc_config.mode.value} "
+        f"Creating {artifact_label} in {doc_config.mode.value} "
         f"({doc_config.appearance}) mode...",
     )
     logger.debug(f"\n{config.diagnostic_details()}")
-    temp_pdf_path = select_engine(config).build(
+    temp_artifact_path = select_engine(config).build(
         PDFBuildContext(config=config, toc=toc)
     )
-    if not temp_pdf_path.exists():
-        raise FileNotFoundError(f"PDF file not found: {temp_pdf_path}")
+    if not temp_artifact_path.exists():
+        raise FileNotFoundError(
+            f"{artifact_label} file not found: {temp_artifact_path}"
+        )
 
     try:
-        shutil.move(str(temp_pdf_path), config.output_path)
-        logger.info(f"PDF saved to {config.output_path}")
+        shutil.move(str(temp_artifact_path), config.output_path)
+        logger.info(f"{artifact_label} saved to {config.output_path}")
     except (OSError, shutil.Error) as e:
         raise RuntimeError(
-            f"Failed to save PDF to {config.output_path}"
+            f"Failed to save {artifact_label} to {config.output_path}"
         ) from e

--- a/src/swift_book_pdf/pdf/cli/command.py
+++ b/src/swift_book_pdf/pdf/cli/command.py
@@ -40,6 +40,7 @@ from swift_book_pdf.pdf.cli.options import (
     pdf_appearance_options,
     pdf_document_options,
     pdf_gutter_option,
+    pdf_output_options,
     pdf_typography_options,
 )
 from swift_book_pdf.pdf.config import EngineKind
@@ -48,6 +49,7 @@ from swift_book_pdf.pdf.config import EngineKind
 @click.command(name="swift-book-pdf", help="")
 @output_path_argument
 @pdf_document_options
+@pdf_output_options
 @apply_backend_build_options
 @override_version_option
 @apply_backend_command_options
@@ -67,6 +69,7 @@ def pdf(  # noqa: PLR0913
     output_path: str,
     mode: str,
     paper: str,
+    save_tex: bool,
     engine: str,
     override_version: str | None,
     font_size: float | None,
@@ -85,6 +88,7 @@ def pdf(  # noqa: PLR0913
         output_path: User-provided output path.
         mode: Rendering mode option value.
         paper: Paper size option value.
+        save_tex: Whether to save LaTeX source instead of compiling a PDF.
         engine: PDF rendering engine option value.
         override_version: Optional Swift version override.
         font_size: Optional base paragraph font size.
@@ -109,11 +113,12 @@ def pdf(  # noqa: PLR0913
     run_build(
         verbose=verbose,
         output_path=output_path,
-        output_format=OutputFormat.PDF,
+        output_format=OutputFormat.TEX if save_tex else OutputFormat.PDF,
         config_builder=partial(
             pdf_config.build_pdf_config,
             backend=backend,
             doc_config=doc_config,
+            save_tex=save_tex,
             backend_options=backend_options,
             override_version=override_version,
             source_ref=source_ref,

--- a/src/swift_book_pdf/pdf/cli/config.py
+++ b/src/swift_book_pdf/pdf/cli/config.py
@@ -65,6 +65,7 @@ def build_pdf_config(  # noqa: PLR0913
     *,
     backend: PDFBackend,
     doc_config: PDFDocumentConfig,
+    save_tex: bool,
     backend_options: Mapping[str, Any],
     override_version: str | None,
     source_ref: str | None,
@@ -79,6 +80,7 @@ def build_pdf_config(  # noqa: PLR0913
         output_path: Validated PDF output path.
         backend: PDF backend adapter.
         doc_config: PDF document layout configuration.
+        save_tex: Whether to save LaTeX source instead of compiling a PDF.
         backend_options: Backend-specific CLI option values.
         override_version: Optional Swift version override.
         source_ref: Optional Swift Book Git ref.
@@ -101,6 +103,7 @@ def build_pdf_config(  # noqa: PLR0913
             output_path=output_path,
             dangerously_skip_legal_notices=dangerously_skip_legal_notices,
             doc_config=doc_config,
+            save_tex=save_tex,
             override_version=override_version,
             backend_options=backend_options,
         )

--- a/src/swift_book_pdf/pdf/cli/options.py
+++ b/src/swift_book_pdf/pdf/cli/options.py
@@ -62,6 +62,25 @@ def pdf_document_options(func: OptionTarget) -> OptionTarget:
     return apply_options(func, decorators)
 
 
+def pdf_output_options(func: OptionTarget) -> OptionTarget:
+    """Add PDF output artifact options to the command callback.
+
+    Args:
+        func: Click command callback to decorate.
+
+    Returns:
+        Decorated command callback.
+    """
+    decorators = (
+        click.option(
+            "--save-tex",
+            is_flag=True,
+            help="Save the generated LaTeX source instead of compiling a PDF",
+        ),
+    )
+    return apply_options(func, decorators)
+
+
 def pdf_typography_options(func: OptionTarget) -> OptionTarget:
     """Add PDF typography options to the command callback.
 

--- a/src/swift_book_pdf/pdf/config.py
+++ b/src/swift_book_pdf/pdf/config.py
@@ -120,6 +120,9 @@ class PDFConfig(BaseBuildConfig, ABC):
     doc_config: PDFDocumentConfig
     """PDF document layout configuration."""
 
+    save_tex: bool = False
+    """Whether to save LaTeX source instead of compiling a PDF."""
+
     engine_kind: EngineKind
     """PDF engine implementation."""
 
@@ -143,6 +146,7 @@ class PDFConfig(BaseBuildConfig, ABC):
                 f"Appearance: {doc_config.appearance}",
                 f"Book Gutter: {doc_config.gutter}",
                 f"Font size: {doc_config.font_size}pt",
+                f"Build target: {'tex' if self.save_tex else 'pdf'}",
             ]
         )
 

--- a/src/swift_book_pdf/pdf/latex/backend.py
+++ b/src/swift_book_pdf/pdf/latex/backend.py
@@ -53,6 +53,7 @@ class LaTeXBackend:
                 config_input.dangerously_skip_legal_notices
             ),
             doc_config=config_input.doc_config,
+            save_tex=config_input.save_tex,
             latex_config=latex_config,
             override_version=config_input.override_version,
         )

--- a/src/swift_book_pdf/pdf/latex/engine.py
+++ b/src/swift_book_pdf/pdf/latex/engine.py
@@ -34,13 +34,13 @@ class LaTeXEngine:
     """Render Swift Book Markdown to LaTeX and compile it to PDF."""
 
     def build(self, context: PDFBuildContext) -> Path:
-        """Build the temporary PDF for a LaTeX-backed PDF build.
+        """Build the temporary artifact for a LaTeX-backed PDF build.
 
         Args:
             context: Shared PDF build inputs.
 
         Returns:
-            Path to the generated temporary PDF.
+            Path to the generated temporary artifact.
         """
         config = _require_latex_config(context.config)
         latex_file_path = Path(config.temp_dir) / "inner_content.tex"
@@ -50,6 +50,9 @@ class LaTeXEngine:
             LaTeXRenderer(config),
             latex_file_path,
         )
+
+        if config.save_tex:
+            return latex_file_path
 
         compiler = LuaLaTeXCompiler(config)
         for _ in trange(config.latex_config.typesets, leave=False):

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -269,9 +269,37 @@ def test_pdf_command_builds_pdf_config_and_calls_pdf_builder(
     assert config_input.doc_config.appearance.value == "dark"
     assert config_input.doc_config.gutter is False
     assert config_input.doc_config.font_size == PDF_FONT_SIZE
+    assert config_input.save_tex is False
     assert config_input.override_version == "6.2 beta"
     assert config_input.dangerously_skip_legal_notices is True
     assert LEGAL_NOTICES_WARNING in result.output
+    build_pdf.assert_called_once_with(fake_config)
+
+
+def test_pdf_command_can_save_tex_instead_of_pdf(
+    runner: CliRunner,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    fake_config = SimpleNamespace(dangerously_skip_legal_notices=False)
+    stub_resolve_cli_build_source(pdf_cli_config, monkeypatch)
+    build_pdf_config = Mock(return_value=fake_config)
+    build_pdf = Mock()
+    monkeypatch.setattr(
+        pdf_cli_backends.select_backend_for_cli(EngineKind.LATEX),
+        "build_config",
+        build_pdf_config,
+    )
+    monkeypatch.setattr(pdf_cli, "build_pdf", build_pdf)
+
+    output_dir = tmp_path / "dist"
+    output_dir.mkdir()
+    result = runner.invoke(pdf_cli.pdf, [str(output_dir), "--save-tex"])
+
+    assert_success(result)
+    config_input = build_pdf_config.call_args.args[0]
+    assert config_input.output_path == str(output_dir / "swift_book.tex")
+    assert config_input.save_tex is True
     build_pdf.assert_called_once_with(fake_config)
 
 

--- a/tests/pdf/test_engine.py
+++ b/tests/pdf/test_engine.py
@@ -14,14 +14,18 @@
 
 from pathlib import Path
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, cast
+from typing import cast
+from unittest.mock import Mock
 
 import pytest
 
+from swift_book_pdf.core.config import ResolvedBuildSource
+from swift_book_pdf.pdf.backend import PDFBuildContext
+from swift_book_pdf.pdf.config import PDFDocumentConfig
 from swift_book_pdf.pdf.latex.build import compiler
-
-if TYPE_CHECKING:
-    from swift_book_pdf.pdf.latex.config import LaTeXPDFConfig
+from swift_book_pdf.pdf.latex.config import LaTeXConfig, LaTeXPDFConfig
+from swift_book_pdf.pdf.latex.engine import LaTeXEngine
+from swift_book_pdf.pdf.latex.fonts.resolver import LaTeXFontConfig
 
 
 def test_pdf_converter_uses_package_assets_dir(
@@ -38,7 +42,7 @@ def test_pdf_converter_uses_package_assets_dir(
     )
 
     converter = compiler.LuaLaTeXCompiler(
-        cast("LaTeXPDFConfig", SimpleNamespace())
+        cast(LaTeXPDFConfig, SimpleNamespace())
     )
 
     asset_dirs = tuple(Path(path) for path in converter.local_asset_dirs)
@@ -48,3 +52,52 @@ def test_pdf_converter_uses_package_assets_dir(
     ]
     assert (asset_dirs[0] / "chapter-icon.png").is_file()
     assert (asset_dirs[1] / "IBMPlexSerif-Regular.ttf").is_file()
+
+
+def test_latex_engine_can_stop_after_writing_tex(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    docc_root = tmp_path / "swift-book" / "TSPL.docc"
+    config = LaTeXPDFConfig(
+        source=ResolvedBuildSource(
+            temp_dir=str(tmp_path),
+            root_dir=str(docc_root),
+            toc_file_path=str(docc_root / "The-Swift-Programming-Language.md"),
+            assets_dir=str(docc_root / "Assets"),
+            original_work_copyright_year_range=(2014, 2026),
+        ),
+        output_path=str(tmp_path / "book.tex"),
+        doc_config=PDFDocumentConfig(),
+        latex_config=LaTeXConfig(
+            font_config=LaTeXFontConfig(
+                main_font="New York",
+                mono_font="Berkeley Mono",
+                emoji_font="Apple Color Emoji",
+                unicode_fonts=("Noto Sans Symbols 2",),
+                header_footer_font="SF Pro",
+            ),
+            typesets=1,
+        ),
+        save_tex=True,
+    )
+    context = PDFBuildContext(config=config, toc=Mock(chapter_metadata={}))
+
+    monkeypatch.setattr(
+        "swift_book_pdf.pdf.latex.engine.write_latex_document",
+        lambda _config, _toc, _renderer, output_path: output_path.write_text(
+            "TEX",
+            encoding="utf-8",
+        ),
+    )
+    compiler_mock = Mock()
+    monkeypatch.setattr(
+        "swift_book_pdf.pdf.latex.engine.LuaLaTeXCompiler",
+        compiler_mock,
+    )
+
+    artifact_path = LaTeXEngine().build(context)
+
+    assert artifact_path == tmp_path / "inner_content.tex"
+    assert artifact_path.read_text(encoding="utf-8") == "TEX"
+    compiler_mock.assert_not_called()


### PR DESCRIPTION
Add --save-tex flag to swift-book-pdf to save the generated LaTeX source instead of compiling a PDF.