### PR TITLE
feat(pdf): persist typesetting intermediate artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bundle IBM Plex Sans and IBM Plex Serif with the EPUB so cover text and front matter render consistently across reading environments, regardless of host-installed fonts.
 - Add a project-owned `swift-book-swift` Pygments lexer for Swift code highlighting, derived from the Highlight.js Swift grammar and registered for both Python and minted/PDF use.
 - Add new `--save-tex` flag to `swift-book-pdf` to save the generated LaTeX source instead of compiling a PDF.
+- Add new `--save-intermediates` flag to `swift-book-pdf` to save the build intermediates to a user-provided directory.
 
 ### Changed
 - Redesign generated EPUB cover artwork and rendered cover text for release and beta editions, with new templates, edition-specific colors, and adjusted version-label spacing and positioning.

--- a/src/swift_book_pdf/pdf/backend.py
+++ b/src/swift_book_pdf/pdf/backend.py
@@ -55,6 +55,9 @@ class PDFBackendConfigInput:
     save_tex: bool
     """Whether to save LaTeX source instead of compiling a PDF."""
 
+    intermediates_path: str | None
+    """Optional destination directory for build intermediates."""
+
     override_version: str | None
     """Optional Swift version override."""
 

--- a/src/swift_book_pdf/pdf/builder.py
+++ b/src/swift_book_pdf/pdf/builder.py
@@ -16,6 +16,7 @@
 
 import logging
 import shutil
+from pathlib import Path
 
 from swift_book_pdf.core.navigation.toc import TableOfContents
 from swift_book_pdf.pdf.backend import PDFBuildContext, select_engine
@@ -57,10 +58,40 @@ def build_pdf(config: PDFConfig) -> None:
             f"{artifact_label} file not found: {temp_artifact_path}"
         )
 
+    if config.intermediates_path is not None:
+        _save_build_directory(config)
+
     try:
         shutil.move(str(temp_artifact_path), config.output_path)
         logger.info(f"{artifact_label} saved to {config.output_path}")
     except (OSError, shutil.Error) as e:
         raise RuntimeError(
             f"Failed to save {artifact_label} to {config.output_path}"
+        ) from e
+
+
+def _save_build_directory(config: PDFConfig) -> None:
+    """Save the complete temporary build directory to a user path.
+
+    Args:
+        config: Resolved PDF build configuration.
+
+    Raises:
+        RuntimeError: If the destination already exists or cannot be written.
+    """
+    if config.intermediates_path is None:
+        raise RuntimeError("Build files directory was not configured.")
+
+    destination = Path(config.intermediates_path)
+    if destination.exists():
+        raise RuntimeError(
+            f"Build files directory already exists: {destination}"
+        )
+
+    try:
+        shutil.copytree(config.temp_dir, destination, symlinks=True)
+        logger.info(f"Build files saved to {destination}")
+    except (OSError, shutil.Error) as e:
+        raise RuntimeError(
+            f"Failed to save build files to {destination}"
         ) from e

--- a/src/swift_book_pdf/pdf/cli/command.py
+++ b/src/swift_book_pdf/pdf/cli/command.py
@@ -70,6 +70,7 @@ def pdf(  # noqa: PLR0913
     mode: str,
     paper: str,
     save_tex: bool,
+    save_intermediates: str | None,
     engine: str,
     override_version: str | None,
     font_size: float | None,
@@ -89,6 +90,8 @@ def pdf(  # noqa: PLR0913
         mode: Rendering mode option value.
         paper: Paper size option value.
         save_tex: Whether to save LaTeX source instead of compiling a PDF.
+        save_intermediates: Optional directory for build intermediates and
+            output.
         engine: PDF rendering engine option value.
         override_version: Optional Swift version override.
         font_size: Optional base paragraph font size.
@@ -101,6 +104,11 @@ def pdf(  # noqa: PLR0913
         verbose: Whether debug logging should be enabled.
         backend_options: Engine-specific option values.
     """
+    if save_tex and save_intermediates is not None:
+        raise click.UsageError(
+            "Use either --save-tex or --save-intermediates, not both."
+        )
+
     backend = select_backend_for_cli(EngineKind(engine))
     doc_config = pdf_config.build_doc_config(
         mode=mode,
@@ -119,6 +127,7 @@ def pdf(  # noqa: PLR0913
             backend=backend,
             doc_config=doc_config,
             save_tex=save_tex,
+            intermediates_path=save_intermediates,
             backend_options=backend_options,
             override_version=override_version,
             source_ref=source_ref,

--- a/src/swift_book_pdf/pdf/cli/config.py
+++ b/src/swift_book_pdf/pdf/cli/config.py
@@ -66,6 +66,7 @@ def build_pdf_config(  # noqa: PLR0913
     backend: PDFBackend,
     doc_config: PDFDocumentConfig,
     save_tex: bool,
+    intermediates_path: str | None,
     backend_options: Mapping[str, Any],
     override_version: str | None,
     source_ref: str | None,
@@ -81,6 +82,8 @@ def build_pdf_config(  # noqa: PLR0913
         backend: PDF backend adapter.
         doc_config: PDF document layout configuration.
         save_tex: Whether to save LaTeX source instead of compiling a PDF.
+        intermediates_path: Optional destination directory for build
+            intermediates.
         backend_options: Backend-specific CLI option values.
         override_version: Optional Swift version override.
         source_ref: Optional Swift Book Git ref.
@@ -104,6 +107,7 @@ def build_pdf_config(  # noqa: PLR0913
             dangerously_skip_legal_notices=dangerously_skip_legal_notices,
             doc_config=doc_config,
             save_tex=save_tex,
+            intermediates_path=intermediates_path,
             override_version=override_version,
             backend_options=backend_options,
         )

--- a/src/swift_book_pdf/pdf/cli/options.py
+++ b/src/swift_book_pdf/pdf/cli/options.py
@@ -77,6 +77,13 @@ def pdf_output_options(func: OptionTarget) -> OptionTarget:
             is_flag=True,
             help="Save the generated LaTeX source instead of compiling a PDF",
         ),
+        click.option(
+            "--save-intermediates",
+            metavar="BUILD_DIRECTORY",
+            type=click.Path(resolve_path=True, file_okay=False),
+            default=None,
+            help="Save build intermediates in this directory",
+        ),
     )
     return apply_options(func, decorators)
 

--- a/src/swift_book_pdf/pdf/config.py
+++ b/src/swift_book_pdf/pdf/config.py
@@ -123,6 +123,9 @@ class PDFConfig(BaseBuildConfig, ABC):
     save_tex: bool = False
     """Whether to save LaTeX source instead of compiling a PDF."""
 
+    intermediates_path: str | None = None
+    """Optional destination directory for build intermediates."""
+
     engine_kind: EngineKind
     """PDF engine implementation."""
 
@@ -147,6 +150,7 @@ class PDFConfig(BaseBuildConfig, ABC):
                 f"Book Gutter: {doc_config.gutter}",
                 f"Font size: {doc_config.font_size}pt",
                 f"Build target: {'tex' if self.save_tex else 'pdf'}",
+                f"Build files: {self.intermediates_path or 'temporary'}",
             ]
         )
 

--- a/src/swift_book_pdf/pdf/latex/backend.py
+++ b/src/swift_book_pdf/pdf/latex/backend.py
@@ -54,6 +54,7 @@ class LaTeXBackend:
             ),
             doc_config=config_input.doc_config,
             save_tex=config_input.save_tex,
+            intermediates_path=config_input.intermediates_path,
             latex_config=latex_config,
             override_version=config_input.override_version,
         )

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -105,6 +105,8 @@ def stub_resolve_cli_build_source(
             (
                 "--mode",
                 "--paper",
+                "--save-tex",
+                "--save-intermediates",
                 "--typesets",
                 "--override-version",
                 "--main",
@@ -223,6 +225,8 @@ def test_pdf_command_builds_pdf_config_and_calls_pdf_builder(
             "a4",
             "--typesets",
             str(PDF_TYPESSETS),
+            "--save-intermediates",
+            "./build-files",
             "--override-version",
             "6.2 beta",
             "--main",
@@ -270,6 +274,7 @@ def test_pdf_command_builds_pdf_config_and_calls_pdf_builder(
     assert config_input.doc_config.gutter is False
     assert config_input.doc_config.font_size == PDF_FONT_SIZE
     assert config_input.save_tex is False
+    assert config_input.intermediates_path == str(tmp_path / "build-files")
     assert config_input.override_version == "6.2 beta"
     assert config_input.dangerously_skip_legal_notices is True
     assert LEGAL_NOTICES_WARNING in result.output
@@ -301,6 +306,29 @@ def test_pdf_command_can_save_tex_instead_of_pdf(
     assert config_input.output_path == str(output_dir / "swift_book.tex")
     assert config_input.save_tex is True
     build_pdf.assert_called_once_with(fake_config)
+
+
+def test_pdf_save_intermediates_requires_directory_path(
+    runner: CliRunner,
+) -> None:
+    result = runner.invoke(pdf_cli.pdf, ["--save-intermediates"])
+
+    assert_failure(result)
+    assert "Option '--save-intermediates' requires an argument" in (
+        result.output
+    )
+
+
+def test_pdf_save_intermediates_conflicts_with_save_tex(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    result = runner.invoke(
+        pdf_cli.pdf,
+        ["--save-tex", "--save-intermediates", str(tmp_path / "build-files")],
+    )
+
+    assert_failure(result)
+    assert "Use either --save-tex or --save-intermediates" in result.output
 
 
 def test_pdf_command_returns_nonzero_on_builder_failure(
@@ -540,6 +568,9 @@ def test_input_path_rejects_revision_selection(
 def test_validate_output_path_handles_format_suffixes(tmp_path: Path) -> None:
     assert validate_output_path(str(tmp_path), OutputFormat.EPUB) == str(
         tmp_path / "swift_book.epub"
+    )
+    assert validate_output_path(str(tmp_path), OutputFormat.TEX) == str(
+        tmp_path / "swift_book.tex"
     )
 
     with pytest.raises(ValueError, match="not a PDF file"):

--- a/tests/pdf/test_builder.py
+++ b/tests/pdf/test_builder.py
@@ -1,0 +1,112 @@
+# Copyright 2026 Evangelos Kassos
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for top-level PDF build artifact handling."""
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import Mock
+
+import pytest
+
+from swift_book_pdf.pdf import builder
+from swift_book_pdf.pdf.config import PDFConfig
+
+
+def test_build_pdf_can_save_intermediates_without_changing_pdf_output(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    temp_dir = tmp_path / "temp"
+    temp_dir.mkdir()
+    (temp_dir / "inner_content.aux").write_text("AUX", encoding="utf-8")
+    temp_artifact_path = temp_dir / "inner_content.pdf"
+    temp_artifact_path.write_text("PDF", encoding="utf-8")
+    output_dir = tmp_path / "build-files"
+    output_path = tmp_path / "swift_book.pdf"
+
+    monkeypatch.setattr(builder, "TableOfContents", Mock())
+    monkeypatch.setattr(
+        builder,
+        "select_engine",
+        Mock(return_value=Mock(build=Mock(return_value=temp_artifact_path))),
+    )
+
+    builder.build_pdf(
+        cast(
+            PDFConfig,
+            SimpleNamespace(
+                root_dir=str(tmp_path / "book"),
+                toc_file_path=str(tmp_path / "toc.md"),
+                temp_dir=str(temp_dir),
+                dangerously_skip_legal_notices=False,
+                doc_config=SimpleNamespace(
+                    mode=SimpleNamespace(value="digital"),
+                    appearance="light",
+                ),
+                save_tex=False,
+                output_path=str(output_path),
+                intermediates_path=str(output_dir),
+                diagnostic_details=lambda: "",
+            ),
+        )
+    )
+
+    assert (output_dir / "inner_content.aux").read_text(
+        encoding="utf-8"
+    ) == "AUX"
+    assert (output_dir / "inner_content.pdf").read_text(
+        encoding="utf-8"
+    ) == "PDF"
+    assert not (output_dir / "swift_book.pdf").exists()
+    assert output_path.read_text(encoding="utf-8") == "PDF"
+
+
+def test_build_pdf_rejects_existing_intermediates_directory(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    temp_dir = tmp_path / "temp"
+    temp_dir.mkdir()
+    temp_artifact_path = temp_dir / "inner_content.pdf"
+    temp_artifact_path.write_text("PDF", encoding="utf-8")
+    output_dir = tmp_path / "build-files"
+    output_dir.mkdir()
+
+    monkeypatch.setattr(builder, "TableOfContents", Mock())
+    monkeypatch.setattr(
+        builder,
+        "select_engine",
+        Mock(return_value=Mock(build=Mock(return_value=temp_artifact_path))),
+    )
+
+    with pytest.raises(RuntimeError, match="already exists"):
+        builder.build_pdf(
+            cast(
+                PDFConfig,
+                SimpleNamespace(
+                    root_dir=str(tmp_path / "book"),
+                    toc_file_path=str(tmp_path / "toc.md"),
+                    temp_dir=str(temp_dir),
+                    dangerously_skip_legal_notices=False,
+                    doc_config=SimpleNamespace(
+                        mode=SimpleNamespace(value="digital"),
+                        appearance="light",
+                    ),
+                    save_tex=False,
+                    output_path=str(tmp_path / "swift_book.pdf"),
+                    intermediates_path=str(output_dir),
+                    diagnostic_details=lambda: "",
+                ),
+            )
+        )


### PR DESCRIPTION
Add new `--save-intermediates` flag to `swift-book-pdf` to save the build intermediates to a user-provided directory.

Resolves #140 