### PR TITLE
feat(pdf): typeset one chapter or only TOCs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add a project-owned `swift-book-swift` Pygments lexer for Swift code highlighting, derived from the Highlight.js Swift grammar and registered for both Python and minted/PDF use.
 - Add new `--save-tex` flag to `swift-book-pdf` to save the generated LaTeX source instead of compiling a PDF.
 - Add new `--save-intermediates` flag to `swift-book-pdf` to save the build intermediates to a user-provided directory.
+- Add new `--only-toc` flag to `swift-book-pdf` to generate only the table of contents.
+- Add new `--only-chapter` flag to `swift-book-pdf` to generate a single chapter by DocC tag (`<doc:TheBasics>`) or file stem (`TheBasics`).
 
 ### Changed
 - Redesign generated EPUB cover artwork and rendered cover text for release and beta editions, with new templates, edition-specific colors, and adjusted version-label spacing and positioning.

--- a/src/swift_book_pdf/pdf/backend.py
+++ b/src/swift_book_pdf/pdf/backend.py
@@ -21,7 +21,12 @@ from typing import Any, Protocol
 
 from swift_book_pdf.core.config import ResolvedBuildSource
 from swift_book_pdf.core.navigation.toc import TableOfContents
-from swift_book_pdf.pdf.config import EngineKind, PDFConfig, PDFDocumentConfig
+from swift_book_pdf.pdf.config import (
+    EngineKind,
+    PDFConfig,
+    PDFContentSelection,
+    PDFDocumentConfig,
+)
 from swift_book_pdf.pdf.latex.backend import LaTeXBackend
 from swift_book_pdf.pdf.latex.engine import LaTeXEngine
 
@@ -51,6 +56,9 @@ class PDFBackendConfigInput:
 
     doc_config: PDFDocumentConfig
     """Resolved PDF document layout options."""
+
+    content_selection: PDFContentSelection
+    """Subset of book content to render."""
 
     save_tex: bool
     """Whether to save LaTeX source instead of compiling a PDF."""

--- a/src/swift_book_pdf/pdf/cli/command.py
+++ b/src/swift_book_pdf/pdf/cli/command.py
@@ -38,6 +38,7 @@ from swift_book_pdf.pdf.cli.backends import (
 )
 from swift_book_pdf.pdf.cli.options import (
     pdf_appearance_options,
+    pdf_content_options,
     pdf_document_options,
     pdf_gutter_option,
     pdf_output_options,
@@ -59,6 +60,7 @@ from swift_book_pdf.pdf.config import EngineKind
     default=default_engine_value(),
     hidden=True,
 )
+@pdf_content_options
 @pdf_typography_options
 @pdf_appearance_options
 @legal_notices_option
@@ -73,6 +75,8 @@ def pdf(  # noqa: PLR0913
     save_intermediates: str | None,
     engine: str,
     override_version: str | None,
+    only_toc: bool,
+    only_chapter: str | None,
     font_size: float | None,
     dark: bool,
     dangerously_skip_legal_notices: bool,
@@ -94,6 +98,8 @@ def pdf(  # noqa: PLR0913
             output.
         engine: PDF rendering engine option value.
         override_version: Optional Swift version override.
+        only_toc: Whether to render only the table of contents page.
+        only_chapter: Optional document tag or file stem for one chapter.
         font_size: Optional base paragraph font size.
         dark: Whether dark mode should be rendered.
         dangerously_skip_legal_notices: Whether generated notices are omitted.
@@ -117,6 +123,10 @@ def pdf(  # noqa: PLR0913
         gutter=gutter,
         font_size=font_size,
     )
+    content_selection = pdf_config.build_content_selection(
+        only_toc=only_toc,
+        only_chapter=only_chapter,
+    )
 
     run_build(
         verbose=verbose,
@@ -126,6 +136,7 @@ def pdf(  # noqa: PLR0913
             pdf_config.build_pdf_config,
             backend=backend,
             doc_config=doc_config,
+            content_selection=content_selection,
             save_tex=save_tex,
             intermediates_path=save_intermediates,
             backend_options=backend_options,

--- a/src/swift_book_pdf/pdf/cli/config.py
+++ b/src/swift_book_pdf/pdf/cli/config.py
@@ -25,6 +25,7 @@ from swift_book_pdf.pdf.config import (
     Appearance,
     PaperSize,
     PDFConfig,
+    PDFContentSelection,
     PDFDocumentConfig,
     RenderingMode,
 )
@@ -59,12 +60,34 @@ def build_doc_config(
     )
 
 
+def build_content_selection(
+    *,
+    only_toc: bool,
+    only_chapter: str | None,
+) -> PDFContentSelection:
+    """Build the PDF content selection from CLI options.
+
+    Args:
+        only_toc: Whether to render only the table of contents page.
+        only_chapter: Optional document tag or file stem for one chapter.
+
+    Returns:
+        PDF content selection.
+    """
+    chapter = only_chapter.strip() if only_chapter is not None else None
+    return PDFContentSelection(
+        only_toc=only_toc,
+        only_chapter=chapter or None,
+    )
+
+
 def build_pdf_config(  # noqa: PLR0913
     temp_dir: str,
     output_path: str,
     *,
     backend: PDFBackend,
     doc_config: PDFDocumentConfig,
+    content_selection: PDFContentSelection,
     save_tex: bool,
     intermediates_path: str | None,
     backend_options: Mapping[str, Any],
@@ -81,6 +104,7 @@ def build_pdf_config(  # noqa: PLR0913
         output_path: Validated PDF output path.
         backend: PDF backend adapter.
         doc_config: PDF document layout configuration.
+        content_selection: Requested content subset.
         save_tex: Whether to save LaTeX source instead of compiling a PDF.
         intermediates_path: Optional destination directory for build
             intermediates.
@@ -106,6 +130,7 @@ def build_pdf_config(  # noqa: PLR0913
             output_path=output_path,
             dangerously_skip_legal_notices=dangerously_skip_legal_notices,
             doc_config=doc_config,
+            content_selection=content_selection,
             save_tex=save_tex,
             intermediates_path=intermediates_path,
             override_version=override_version,

--- a/src/swift_book_pdf/pdf/cli/options.py
+++ b/src/swift_book_pdf/pdf/cli/options.py
@@ -62,6 +62,31 @@ def pdf_document_options(func: OptionTarget) -> OptionTarget:
     return apply_options(func, decorators)
 
 
+def pdf_content_options(func: OptionTarget) -> OptionTarget:
+    """Add PDF content selection options to the command callback.
+
+    Args:
+        func: Click command callback to decorate.
+
+    Returns:
+        Decorated command callback.
+    """
+    decorators = (
+        click.option(
+            "--only-toc",
+            is_flag=True,
+            help="Render only the table of contents page",
+        ),
+        click.option(
+            "--only-chapter",
+            metavar="DOC_TAG",
+            default=None,
+            help="Render only one chapter by DocC tag or file stem",
+        ),
+    )
+    return apply_options(func, decorators)
+
+
 def pdf_output_options(func: OptionTarget) -> OptionTarget:
     """Add PDF output artifact options to the command callback.
 

--- a/src/swift_book_pdf/pdf/config.py
+++ b/src/swift_book_pdf/pdf/config.py
@@ -15,7 +15,7 @@
 """Shared PDF build configuration."""
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import ClassVar
 
@@ -107,6 +107,33 @@ class PDFDocumentConfig:
             raise ValueError("Font size must be a positive number.")
 
 
+@dataclass(frozen=True)
+class PDFContentSelection:
+    """Subset of book content to render for a PDF build.
+
+    Attributes:
+        only_toc: Whether to render only the table of contents page.
+        only_chapter: Optional document tag or file stem for one chapter.
+    """
+
+    only_toc: bool = False
+    """Whether to render only the table of contents page."""
+
+    only_chapter: str | None = None
+    """Optional document tag or file stem for one chapter."""
+
+    def __post_init__(self) -> None:
+        """Validate the requested content subset.
+
+        Raises:
+            ValueError: If incompatible content selectors are set.
+        """
+        if self.only_toc and self.only_chapter is not None:
+            raise ValueError(
+                "Use either --only-toc or --only-chapter, not both."
+            )
+
+
 @dataclass(frozen=True, kw_only=True)
 class PDFConfig(BaseBuildConfig, ABC):
     """Resolved configuration for PDF builds.
@@ -120,17 +147,22 @@ class PDFConfig(BaseBuildConfig, ABC):
     doc_config: PDFDocumentConfig
     """PDF document layout configuration."""
 
-    save_tex: bool = False
-    """Whether to save LaTeX source instead of compiling a PDF."""
-
-    intermediates_path: str | None = None
-    """Optional destination directory for build intermediates."""
-
     engine_kind: EngineKind
     """PDF engine implementation."""
 
     override_version: str | None = None
     """Optional Swift version override."""
+
+    content_selection: PDFContentSelection = field(
+        default_factory=PDFContentSelection
+    )
+    """Subset of book content to render."""
+
+    save_tex: bool = False
+    """Whether to save LaTeX source instead of compiling a PDF."""
+
+    intermediates_path: str | None = None
+    """Optional destination directory for build intermediates."""
 
     output_format: ClassVar[OutputFormat] = OutputFormat.PDF
     """Artifact format produced by PDF builders."""
@@ -149,6 +181,7 @@ class PDFConfig(BaseBuildConfig, ABC):
                 f"Appearance: {doc_config.appearance}",
                 f"Book Gutter: {doc_config.gutter}",
                 f"Font size: {doc_config.font_size}pt",
+                f"Content: {format_content_selection(self.content_selection)}",
                 f"Build target: {'tex' if self.save_tex else 'pdf'}",
                 f"Build files: {self.intermediates_path or 'temporary'}",
             ]
@@ -161,3 +194,19 @@ class PDFConfig(BaseBuildConfig, ABC):
         Returns:
             Human-readable backend details.
         """
+
+
+def format_content_selection(selection: PDFContentSelection) -> str:
+    """Format a PDF content selection for diagnostics.
+
+    Args:
+        selection: Requested content subset.
+
+    Returns:
+        Human-readable content selector.
+    """
+    if selection.only_toc:
+        return "toc"
+    if selection.only_chapter is not None:
+        return f"chapter:{selection.only_chapter}"
+    return "full"

--- a/src/swift_book_pdf/pdf/latex/backend.py
+++ b/src/swift_book_pdf/pdf/latex/backend.py
@@ -53,6 +53,7 @@ class LaTeXBackend:
                 config_input.dangerously_skip_legal_notices
             ),
             doc_config=config_input.doc_config,
+            content_selection=config_input.content_selection,
             save_tex=config_input.save_tex,
             intermediates_path=config_input.intermediates_path,
             latex_config=latex_config,

--- a/src/swift_book_pdf/pdf/latex/document.py
+++ b/src/swift_book_pdf/pdf/latex/document.py
@@ -43,26 +43,75 @@ def write_latex_document(
         output_path: Destination ``.tex`` file path.
     """
     latex = generate_preamble(config)
-    toc_latex = generate_toc_latex(toc, renderer)
-    latex += toc_latex + "\n"
 
-    for tag in toc.doc_tags:
-        if tag.lower() == NOTICES_DOC_KEY:
-            latex += render_notices_latex(
-                config.doc_config.mode,
-                config.original_work_copyright_year_range,
+    if config.content_selection.only_toc:
+        latex += generate_toc_latex(toc, renderer) + "\n"
+    elif config.content_selection.only_chapter is not None:
+        latex += _render_chapter(
+            config,
+            toc,
+            renderer,
+            config.content_selection.only_chapter,
+            required=True,
+        )
+    else:
+        latex += generate_toc_latex(toc, renderer) + "\n"
+        for tag in toc.doc_tags:
+            latex += _render_chapter(
+                config, toc, renderer, tag, required=False
             )
-            latex += "\n"
-            continue
-
-        chapter_metadata = toc.chapter_metadata.get(tag.lower())
-        if chapter_metadata is None or chapter_metadata.file_path is None:
-            logger.warning(
-                f"Warning: No file found for tag <doc:{tag}>, skipping...",
-            )
-            continue
-
-        latex += renderer.render_file(chapter_metadata.file_path) + "\n"
 
     latex += r"\end{document}"
     output_path.write_text(latex, encoding="utf-8")
+
+
+def _render_chapter(
+    config: LaTeXPDFConfig,
+    toc: TableOfContents,
+    renderer: LaTeXRenderer,
+    tag: str,
+    *,
+    required: bool,
+) -> str:
+    """Render one chapter by document tag or file stem.
+
+    Args:
+        config: Resolved PDF build configuration.
+        toc: Loaded Swift Book table of contents.
+        renderer: Chapter renderer for source Markdown files.
+        tag: Document tag or file stem.
+        required: Whether missing chapter metadata should fail the build.
+
+    Returns:
+        Rendered chapter LaTeX, including a trailing newline.
+
+    Raises:
+        ValueError: If `tag` does not match a known chapter.
+    """
+    chapter_key = tag.lower()
+    if chapter_key == NOTICES_DOC_KEY:
+        return (
+            render_notices_latex(
+                config.doc_config.mode,
+                config.original_work_copyright_year_range,
+            )
+            + "\n"
+        )
+
+    chapter_metadata = toc.chapter_metadata.get(chapter_key)
+    if chapter_metadata is None:
+        if required:
+            raise ValueError(f"Couldn't find chapter <doc:{tag}>.")
+        logger.warning(
+            f"Warning: No file found for tag <doc:{tag}>, skipping...",
+        )
+        return ""
+    if chapter_metadata.file_path is None:
+        if required:
+            raise ValueError(f"Couldn't find source file for <doc:{tag}>.")
+        logger.warning(
+            f"Warning: No file found for tag <doc:{tag}>, skipping...",
+        )
+        return ""
+
+    return renderer.render_file(chapter_metadata.file_path) + "\n"

--- a/src/swift_book_pdf/pdf/latex/render/blocks.py
+++ b/src/swift_book_pdf/pdf/latex/render/blocks.py
@@ -28,7 +28,6 @@ from swift_book_pdf.core.blocks.models import (
     TermListBlock,
     UnorderedListBlock,
 )
-from swift_book_pdf.pdf.config import RenderingMode
 from swift_book_pdf.pdf.latex.render.code_spans import convert_inline_code
 from swift_book_pdf.pdf.latex.render.context import LaTeXRenderContext
 from swift_book_pdf.pdf.latex.render.escaping import override_characters
@@ -83,23 +82,27 @@ def _convert_block_to_latex(  # noqa: PLR0911
                 block, context.assets_dir, context.appearance
             )
         case NoteBlock():
-            return _convert_note_block(block, context.mode)
+            return _convert_note_block(block, context)
         case ParagraphBlock():
-            return [_convert_paragraph_block(block, context.mode)]
+            return [_convert_paragraph_block(block, context)]
         case TableBlock():
             return convert_table_block(
                 block,
                 context.mode,
                 context.main_font,
                 context.body_font_size,
+                context.doc_references,
             )
         case UnorderedListBlock() | OrderedListBlock() | TermListBlock():
-            list_block = convert_list_like_block(block, context.mode)
+            list_block = convert_list_like_block(block, context)
             if list_block is not None:
                 return list_block
         case Header2Block() | Header3Block() | Header4Block():
             header_block = convert_header_like_block(
-                block, context.file_name, context.mode
+                block,
+                context.file_name,
+                context.mode,
+                context.doc_references,
             )
             if header_block is not None:
                 return header_block
@@ -122,18 +125,20 @@ def _convert_code_block(block: CodeBlock) -> list[str]:
     return output
 
 
-def _convert_note_block(block: NoteBlock, mode: RenderingMode) -> list[str]:
+def _convert_note_block(
+    block: NoteBlock, context: LaTeXRenderContext
+) -> list[str]:
     """Render a note block as an aside box.
 
     Args:
         block: Parsed note block.
-        mode: PDF rendering mode.
+        context: LaTeX rendering state for the current document.
 
     Returns:
         Rendered LaTeX lines.
     """
     aside_content = "\n".join(
-        convert_nested_block(sub_block, mode) for sub_block in block.blocks
+        convert_nested_block(sub_block, context) for sub_block in block.blocks
     )
     return [
         "\\begin{flushleft}\\begin{asideNote}",
@@ -144,18 +149,20 @@ def _convert_note_block(block: NoteBlock, mode: RenderingMode) -> list[str]:
 
 
 def _convert_paragraph_block(
-    block: ParagraphBlock, mode: RenderingMode
+    block: ParagraphBlock, context: LaTeXRenderContext
 ) -> str:
     """Render a paragraph block with inline Markdown formatting.
 
     Args:
         block: Parsed paragraph block.
-        mode: PDF rendering mode.
+        context: LaTeX rendering state for the current document.
 
     Returns:
         Rendered LaTeX paragraph line.
     """
     paragraph = apply_formatting(
-        convert_inline_code(" ".join(block.lines)), mode
+        convert_inline_code(" ".join(block.lines)),
+        context.mode,
+        context.doc_references,
     )
     return f"\\ParagraphStyle{{{paragraph}}}\n"

--- a/src/swift_book_pdf/pdf/latex/render/context.py
+++ b/src/swift_book_pdf/pdf/latex/render/context.py
@@ -17,6 +17,7 @@
 from dataclasses import dataclass
 
 from swift_book_pdf.pdf.config import Appearance, RenderingMode
+from swift_book_pdf.pdf.latex.render.inline import DocReferenceResolver
 
 
 @dataclass(frozen=True)
@@ -40,3 +41,6 @@ class LaTeXRenderContext:
 
     body_font_size: float
     """Base paragraph font size in points."""
+
+    doc_references: DocReferenceResolver | None = None
+    """Optional resolver for subset-build document references."""

--- a/src/swift_book_pdf/pdf/latex/render/headings.py
+++ b/src/swift_book_pdf/pdf/latex/render/headings.py
@@ -22,13 +22,17 @@ from swift_book_pdf.core.blocks.models import (
 )
 from swift_book_pdf.pdf.config import RenderingMode
 from swift_book_pdf.pdf.latex.render.code_spans import convert_inline_code
-from swift_book_pdf.pdf.latex.render.inline import apply_formatting
+from swift_book_pdf.pdf.latex.render.inline import (
+    DocReferenceResolver,
+    apply_formatting,
+)
 
 
 def convert_header_like_block(
     block: Block,
     file_name: str,
     mode: RenderingMode,
+    doc_references: DocReferenceResolver | None = None,
 ) -> list[str] | None:
     """Render a header block when the block is a supported heading level.
 
@@ -36,6 +40,7 @@ def convert_header_like_block(
         block: Candidate parsed block.
         file_name: Current document key used for labels.
         mode: PDF rendering mode.
+        doc_references: Optional resolver for subset-build document refs.
 
     Returns:
         Rendered LaTeX heading line, or `None` for non-heading blocks.
@@ -43,19 +48,31 @@ def convert_header_like_block(
     if isinstance(block, Header2Block):
         return [
             _convert_header_block(
-                block.content, file_name, mode, "SectionHeader"
+                block.content,
+                file_name,
+                mode,
+                "SectionHeader",
+                doc_references,
             )
         ]
     if isinstance(block, Header3Block):
         return [
             _convert_header_block(
-                block.content, file_name, mode, "SubsectionHeader"
+                block.content,
+                file_name,
+                mode,
+                "SubsectionHeader",
+                doc_references,
             )
         ]
     if isinstance(block, Header4Block):
         return [
             _convert_header_block(
-                block.content, file_name, mode, "SubsubsectionHeader"
+                block.content,
+                file_name,
+                mode,
+                "SubsubsectionHeader",
+                doc_references,
             )
         ]
     return None
@@ -66,6 +83,7 @@ def _convert_header_block(
     file_name: str,
     mode: RenderingMode,
     command: str,
+    doc_references: DocReferenceResolver | None,
 ) -> str:
     """Render one heading as a labeled LaTeX command.
 
@@ -74,6 +92,7 @@ def _convert_header_block(
         file_name: Current document key used for labels.
         mode: PDF rendering mode.
         command: LaTeX heading command name.
+        doc_references: Optional resolver for subset-build document refs.
 
     Returns:
         Rendered LaTeX heading line.
@@ -84,6 +103,6 @@ def _convert_header_block(
     )
     file_label = file_name.replace("'", "")
     return (
-        f"\\{command}{{{apply_formatting(inline_content, mode)}}}"
+        f"\\{command}{{{apply_formatting(inline_content, mode, doc_references)}}}"
         f"{{{file_label}_{label_name}}}\n"
     )

--- a/src/swift_book_pdf/pdf/latex/render/inline.py
+++ b/src/swift_book_pdf/pdf/latex/render/inline.py
@@ -15,7 +15,10 @@
 """Inline Markdown formatting for LaTeX output."""
 
 import re
+from collections.abc import Mapping
+from dataclasses import dataclass
 
+from swift_book_pdf.core.source import ChapterMetadata
 from swift_book_pdf.pdf.config import RenderingMode
 from swift_book_pdf.pdf.latex.render.escaping import override_characters
 from swift_book_pdf.pdf.latex.render.links import (
@@ -28,7 +31,60 @@ UNDERSCORE_EMPHASIS_PATTERN = re.compile(
 )
 
 
-def apply_formatting(text: str, mode: RenderingMode) -> str:
+@dataclass(frozen=True)
+class DocReferenceResolver:
+    """Resolve document references that cannot exist in subset builds.
+
+    Attributes:
+        chapter_metadata: Chapter metadata keyed by normalized document key.
+        live_reference_prefixes: Label prefixes emitted by the current subset.
+    """
+
+    chapter_metadata: Mapping[str, ChapterMetadata]
+    """Chapter metadata keyed by normalized document key."""
+
+    live_reference_prefixes: frozenset[str]
+    """Label prefixes emitted by the current subset."""
+
+    def static_text_for_missing_reference(self, key: str) -> str | None:
+        """Return static text when a target label is outside the subset.
+
+        Args:
+            key: Normalized LaTeX reference label.
+
+        Returns:
+            Static chapter title for missing cross-chapter references, or
+            `None` when the reference should remain live.
+        """
+        if self._can_resolve_live(key):
+            return None
+
+        chapter_key = key.split("_", maxsplit=1)[0]
+        metadata = self.chapter_metadata.get(chapter_key)
+        if metadata is None:
+            return None
+        return metadata.header_line
+
+    def _can_resolve_live(self, key: str) -> bool:
+        """Return whether the current subset should emit `key`.
+
+        Args:
+            key: Normalized LaTeX reference label.
+
+        Returns:
+            Whether the label is expected in the rendered subset.
+        """
+        return any(
+            key == prefix or key.startswith(f"{prefix}_")
+            for prefix in self.live_reference_prefixes
+        )
+
+
+def apply_formatting(
+    text: str,
+    mode: RenderingMode,
+    doc_references: DocReferenceResolver | None = None,
+) -> str:
     """Apply Markdown inline formatting and source glyph overrides.
 
     Notes:
@@ -39,6 +95,7 @@ def apply_formatting(text: str, mode: RenderingMode) -> str:
     Args:
         text: Markdown text after inline code conversion.
         mode: PDF rendering mode.
+        doc_references: Optional resolver for subset-build document refs.
 
     Returns:
         LaTeX-safe formatted text.
@@ -65,13 +122,13 @@ def apply_formatting(text: str, mode: RenderingMode) -> str:
     # Escape literal currency/math markers from source text before we inject
     # formatter-owned LaTeX snippets that intentionally use math mode.
     text = text.replace("$", r"\$")
-    text = _apply_text_formatting(text, mode)
+    text = _apply_text_formatting(text, mode, doc_references)
 
     text = restore_markdown_links(
         text,
         markdown_links,
         mode,
-        lambda label: _apply_text_formatting(label, mode),
+        lambda label: _apply_text_formatting(label, mode, doc_references),
     )
 
     # Restore the inline code segments.
@@ -81,12 +138,17 @@ def apply_formatting(text: str, mode: RenderingMode) -> str:
     return override_characters(text)
 
 
-def _apply_text_formatting(text: str, mode: RenderingMode) -> str:
+def _apply_text_formatting(
+    text: str,
+    mode: RenderingMode,
+    doc_references: DocReferenceResolver | None,
+) -> str:
     """Apply inline Markdown transforms that operate on plain text.
 
     Args:
         text: Markdown text with protected inline segments removed.
         mode: PDF rendering mode.
+        doc_references: Optional resolver for subset-build document refs.
 
     Returns:
         Text with inline Markdown converted to LaTeX snippets.
@@ -105,27 +167,42 @@ def _apply_text_formatting(text: str, mode: RenderingMode) -> str:
         lambda m: _format_doc_reference(
             mode,
             f"{m.group(1).lower()}_{m.group(2).lower()}",
+            doc_references,
         ),
         text,
     )
     text = re.sub(
         r"<doc:([^>#]+)>",
-        lambda m: _format_doc_reference(mode, m.group(1).lower()),
+        lambda m: _format_doc_reference(
+            mode,
+            m.group(1).lower(),
+            doc_references,
+        ),
         text,
     )
     return re.sub(r"(?<!\\)#", r"\#", text)
 
 
-def _format_doc_reference(mode: RenderingMode, key: str) -> str:
+def _format_doc_reference(
+    mode: RenderingMode,
+    key: str,
+    doc_references: DocReferenceResolver | None,
+) -> str:
     """Format a Swift Book doc reference for the active rendering mode.
 
     Args:
         mode: PDF rendering mode.
         key: Normalized document reference key.
+        doc_references: Optional resolver for subset-build document refs.
 
     Returns:
         LaTeX fallback reference command.
     """
+    if doc_references is not None:
+        static_text = doc_references.static_text_for_missing_reference(key)
+        if static_text is not None:
+            return static_text
+
     command = (
         "\\fallbackrefbook"
         if mode == RenderingMode.PRINT

--- a/src/swift_book_pdf/pdf/latex/render/lists.py
+++ b/src/swift_book_pdf/pdf/latex/render/lists.py
@@ -20,43 +20,43 @@ from swift_book_pdf.core.blocks.models import (
     TermListBlock,
     UnorderedListBlock,
 )
-from swift_book_pdf.pdf.config import RenderingMode
 from swift_book_pdf.pdf.latex.render.code_spans import convert_inline_code
+from swift_book_pdf.pdf.latex.render.context import LaTeXRenderContext
 from swift_book_pdf.pdf.latex.render.inline import apply_formatting
 from swift_book_pdf.pdf.latex.render.nested import convert_nested_block
 
 
 def convert_list_like_block(
     block: Block,
-    mode: RenderingMode,
+    context: LaTeXRenderContext,
 ) -> list[str] | None:
     """Render a list block when the block is a supported list type.
 
     Args:
         block: Candidate parsed block.
-        mode: PDF rendering mode.
+        context: LaTeX rendering state for the current document.
 
     Returns:
         Rendered LaTeX list lines, or `None` for non-list blocks.
     """
     if isinstance(block, UnorderedListBlock):
-        return _convert_unordered_list_block(block, mode)
+        return _convert_unordered_list_block(block, context)
     if isinstance(block, OrderedListBlock):
-        return _convert_ordered_list_block(block, mode)
+        return _convert_ordered_list_block(block, context)
     if isinstance(block, TermListBlock):
-        return _convert_term_list_block(block, mode)
+        return _convert_term_list_block(block, context)
     return None
 
 
 def _convert_unordered_list_block(
     block: UnorderedListBlock,
-    mode: RenderingMode,
+    context: LaTeXRenderContext,
 ) -> list[str]:
     """Render a parsed unordered list as an itemize environment.
 
     Args:
         block: Parsed unordered list block.
-        mode: PDF rendering mode.
+        context: LaTeX rendering state for the current document.
 
     Returns:
         Rendered LaTeX lines.
@@ -64,26 +64,26 @@ def _convert_unordered_list_block(
     output = [r"\begin{itemize}"]
     for item in block.items:
         if item:
-            output.extend(_convert_unordered_list_item(item, mode))
+            output.extend(_convert_unordered_list_item(item, context))
     output.append(r"\end{itemize}" + "\n\\global\\AtPageTopfalse\n")
     return output
 
 
 def _convert_unordered_list_item(
-    item: list[Block], mode: RenderingMode
+    item: list[Block], context: LaTeXRenderContext
 ) -> list[str]:
     """Render nested blocks that make up one unordered-list item.
 
     Args:
         item: Parsed nested blocks for one list item.
-        mode: PDF rendering mode.
+        context: LaTeX rendering state for the current document.
 
     Returns:
         Rendered LaTeX lines for the item.
     """
     output: list[str] = []
     for index, sub_block in enumerate(item):
-        latex_sub = convert_nested_block(sub_block, mode)
+        latex_sub = convert_nested_block(sub_block, context)
         if index == 0:
             output.append(f"\\item \\ParagraphStyle{{{latex_sub}}}\n")
         elif latex_sub.startswith(r"\parskip"):
@@ -95,20 +95,20 @@ def _convert_unordered_list_item(
 
 def _convert_ordered_list_block(
     block: OrderedListBlock,
-    mode: RenderingMode,
+    context: LaTeXRenderContext,
 ) -> list[str]:
     """Render a parsed ordered list as an enumerate environment.
 
     Args:
         block: Parsed ordered list block.
-        mode: PDF rendering mode.
+        context: LaTeX rendering state for the current document.
 
     Returns:
         Rendered LaTeX lines.
     """
     output = [r"\begin{enumerate}"]
     output.extend(
-        f"\\item {apply_formatting(convert_inline_code(item), mode)}"
+        f"\\item {apply_formatting(convert_inline_code(item), context.mode, context.doc_references)}"
         for item in block.items
     )
     output.append(r"\end{enumerate}" + "\n\\global\\AtPageTopfalse\n")
@@ -116,22 +116,28 @@ def _convert_ordered_list_block(
 
 
 def _convert_term_list_block(
-    block: TermListBlock, mode: RenderingMode
+    block: TermListBlock, context: LaTeXRenderContext
 ) -> list[str]:
     """Render a term list as labeled prose blocks.
 
     Args:
         block: Parsed term list block.
-        mode: PDF rendering mode.
+        context: LaTeX rendering state for the current document.
 
     Returns:
         Rendered LaTeX lines.
     """
     output = ["\\ParagraphStyle{"]
     for term in block.items:
-        label_conv = apply_formatting(convert_inline_code(term.label), mode)
+        label_conv = apply_formatting(
+            convert_inline_code(term.label),
+            context.mode,
+            context.doc_references,
+        )
         content_conv = apply_formatting(
-            convert_inline_code(term.content), mode
+            convert_inline_code(term.content),
+            context.mode,
+            context.doc_references,
         )
         output.append(
             f"\\needspace{{3\\baselineskip}} {label_conv} \\vspace*{{-0.09in}} \\begin{{quote}} {content_conv} \\end{{quote}}",

--- a/src/swift_book_pdf/pdf/latex/render/nested.py
+++ b/src/swift_book_pdf/pdf/latex/render/nested.py
@@ -15,18 +15,20 @@
 """Nested block rendering used by list and aside renderers."""
 
 from swift_book_pdf.core.blocks.models import Block, CodeBlock, ParagraphBlock
-from swift_book_pdf.pdf.config import RenderingMode
 from swift_book_pdf.pdf.latex.render.code_spans import convert_inline_code
+from swift_book_pdf.pdf.latex.render.context import LaTeXRenderContext
 from swift_book_pdf.pdf.latex.render.escaping import override_characters
-from swift_book_pdf.pdf.latex.render.inline import apply_formatting
+from swift_book_pdf.pdf.latex.render.inline import (
+    apply_formatting,
+)
 
 
-def convert_nested_block(block: Block, mode: RenderingMode) -> str:
+def convert_nested_block(block: Block, context: LaTeXRenderContext) -> str:
     """Render a block nested inside another block.
 
     Args:
         block: Parsed nested block.
-        mode: PDF rendering mode.
+        context: LaTeX rendering state for the current document.
 
     Returns:
         Rendered LaTeX for the nested block.
@@ -36,7 +38,9 @@ def convert_nested_block(block: Block, mode: RenderingMode) -> str:
     """
     if isinstance(block, ParagraphBlock):
         para = " ".join(block.lines)
-        return apply_formatting(convert_inline_code(para), mode)
+        return apply_formatting(
+            convert_inline_code(para), context.mode, context.doc_references
+        )
     if isinstance(block, CodeBlock):
         out = "\\parskip=0pt\n" + r"\begin{swiftstyledbox}" + "\n"
         for line in block.lines:

--- a/src/swift_book_pdf/pdf/latex/render/tables.py
+++ b/src/swift_book_pdf/pdf/latex/render/tables.py
@@ -17,7 +17,10 @@
 from swift_book_pdf.core.blocks.models import TableBlock
 from swift_book_pdf.pdf.config import RenderingMode
 from swift_book_pdf.pdf.latex.render.code_spans import convert_inline_code
-from swift_book_pdf.pdf.latex.render.inline import apply_formatting
+from swift_book_pdf.pdf.latex.render.inline import (
+    DocReferenceResolver,
+    apply_formatting,
+)
 from swift_book_pdf.pdf.latex.styling.typography import (
     get_font_size,
     get_spacing,
@@ -29,6 +32,7 @@ def convert_table_block(
     mode: RenderingMode,
     main_font: str,
     body_font_size: float = 9.0,
+    doc_references: DocReferenceResolver | None = None,
 ) -> list[str]:
     """Render a Markdown table block as a LaTeX table.
 
@@ -37,6 +41,7 @@ def convert_table_block(
         mode: PDF rendering mode.
         main_font: Resolved main text font.
         body_font_size: Base paragraph font size in points.
+        doc_references: Optional resolver for subset-build document refs.
 
     Returns:
         Rendered LaTeX table lines.
@@ -60,14 +65,17 @@ def convert_table_block(
         f"\\begin{{tabulary}}{{1.0\\textwidth}}{{{'|'.join('L' for _ in header_row)}}}",
     )
     output.append(
-        format_table_row(header_row, mode, bold=True) + " \\\\ \\hline"
+        format_table_row(header_row, mode, doc_references, bold=True)
+        + " \\\\ \\hline"
     )
     output.extend(
-        format_table_row(row, mode) + " \\\\ \\hline"
+        format_table_row(row, mode, doc_references) + " \\\\ \\hline"
         for row in block.rows[1:-1]
     )
     if block.rows[-1]:
-        output.append(format_table_row(block.rows[-1], mode) + " \\\\")
+        output.append(
+            format_table_row(block.rows[-1], mode, doc_references) + " \\\\"
+        )
     output.extend(["\\end{tabulary}", "\\end{table}", "\n"])
     return output
 
@@ -75,6 +83,7 @@ def convert_table_block(
 def format_table_row(
     row: list[str],
     mode: RenderingMode,
+    doc_references: DocReferenceResolver | None = None,
     *,
     bold: bool = False,
 ) -> str:
@@ -83,12 +92,16 @@ def format_table_row(
     Args:
         row: Raw cell text values.
         mode: PDF rendering mode.
+        doc_references: Optional resolver for subset-build document refs.
         bold: Whether every cell should be bold.
 
     Returns:
         LaTeX row content joined with column separators.
     """
-    cells = [apply_formatting(convert_inline_code(cell), mode) for cell in row]
+    cells = [
+        apply_formatting(convert_inline_code(cell), mode, doc_references)
+        for cell in row
+    ]
     if bold:
         cells = [f"\\textbf{{{cell}}}" for cell in cells]
     return " & ".join(cells)

--- a/src/swift_book_pdf/pdf/latex/render/toc.py
+++ b/src/swift_book_pdf/pdf/latex/render/toc.py
@@ -28,6 +28,7 @@ from swift_book_pdf.core.navigation.toc import TableOfContents
 from swift_book_pdf.core.source import ChapterMetadata
 from swift_book_pdf.core.source.paths import get_file_name
 from swift_book_pdf.pdf.config import Appearance, RenderingMode
+from swift_book_pdf.pdf.latex.render.inline import apply_formatting
 
 if TYPE_CHECKING:
     from swift_book_pdf.pdf.latex.renderer import LaTeXRenderer
@@ -64,6 +65,7 @@ def generate_toc_latex(
         toc.chapter_metadata,
         converter.config.doc_config.mode,
         converter.config.doc_config.appearance,
+        resolve_references=not converter.config.content_selection.only_toc,
     )
     return "\n".join(toc_latex_lines)
 
@@ -73,6 +75,8 @@ def apply_toc_latex_overrides(
     chapter_metadata: dict[str, ChapterMetadata],
     mode: RenderingMode,
     appearance: Appearance,
+    *,
+    resolve_references: bool = True,
 ) -> list[str]:
     """Apply PDF-specific table-of-contents LaTeX overrides.
 
@@ -81,6 +85,7 @@ def apply_toc_latex_overrides(
         chapter_metadata: Chapter metadata keyed by normalized document key.
         mode: PDF rendering mode.
         appearance: PDF color appearance.
+        resolve_references: Whether TOC items should use LaTeX references.
 
     Returns:
         Adjusted LaTeX lines for the PDF table of contents.
@@ -95,6 +100,7 @@ def apply_toc_latex_overrides(
         chapter_metadata,
         mode,
         appearance,
+        resolve_references=resolve_references,
     )
 
 
@@ -103,6 +109,8 @@ def replace_chapter_href_with_toc_item(
     chapter_metadata: dict[str, ChapterMetadata],
     mode: RenderingMode,
     appearance: Appearance,
+    *,
+    resolve_references: bool = True,
 ) -> list[str]:
     """Replace chapter references with LaTeX table-of-contents items.
 
@@ -111,6 +119,7 @@ def replace_chapter_href_with_toc_item(
         chapter_metadata: Chapter metadata keyed by normalized document key.
         mode: PDF rendering mode.
         appearance: PDF color appearance.
+        resolve_references: Whether TOC items should use LaTeX references.
 
     Returns:
         Lines with chapter references replaced by table-of-contents items.
@@ -146,7 +155,13 @@ def replace_chapter_href_with_toc_item(
                     chapter_metadata.get(key, ChapterMetadata()).subtitle_line
                     or ""
                 )
-                return rf"\needspace{{2\baselineskip}}\item[{{{icon_markup}}}] \nameref{{{key}}} \\ {subtitle}"
+                title = _toc_item_title(
+                    key,
+                    chapter_metadata,
+                    mode,
+                    resolve_references=resolve_references,
+                )
+                return rf"\needspace{{2\baselineskip}}\item[{{{icon_markup}}}] {title} \\ {subtitle}"
 
         case RenderingMode.PRINT:
             pattern = re.compile(
@@ -167,7 +182,19 @@ def replace_chapter_href_with_toc_item(
                     chapter_metadata.get(key, ChapterMetadata()).subtitle_line
                     or ""
                 )
-                return rf"\needspace{{2\baselineskip}}\item[{{{icon_markup}}}] \nameref{{{key}}} {{\textcolor{{aside_border}}{{\hrulefill}}}} \pageref{{{key}}} \\ {subtitle}"
+                title = _toc_item_title(
+                    key,
+                    chapter_metadata,
+                    mode,
+                    resolve_references=resolve_references,
+                )
+                page_ref = (
+                    rf" {{\textcolor{{aside_border}}{{\hrulefill}}}} \pageref{{{key}}}"
+                    if resolve_references
+                    else ""
+                )
+
+                return rf"\needspace{{2\baselineskip}}\item[{{{icon_markup}}}] {title} {page_ref} \\ {subtitle}"
 
         case _:
             raise ValueError("Invalid rendering mode specified.")
@@ -177,3 +204,27 @@ def replace_chapter_href_with_toc_item(
         updated_lines.append(updated_line)
 
     return updated_lines
+
+
+def _toc_item_title(
+    key: str,
+    chapter_metadata: dict[str, ChapterMetadata],
+    mode: RenderingMode,
+    *,
+    resolve_references: bool,
+) -> str:
+    """Return a TOC item title for live or static rendering.
+
+    Args:
+        key: Normalized document key.
+        chapter_metadata: Chapter metadata keyed by normalized document key.
+        mode: PDF rendering mode.
+        resolve_references: Whether TOC items should use LaTeX references.
+
+    Returns:
+        LaTeX for the TOC item title.
+    """
+    if resolve_references:
+        return rf"\nameref{{{key}}}"
+    title = chapter_metadata.get(key, ChapterMetadata()).header_line or key
+    return apply_formatting(title, mode)

--- a/src/swift_book_pdf/pdf/latex/renderer.py
+++ b/src/swift_book_pdf/pdf/latex/renderer.py
@@ -14,6 +14,7 @@
 
 """Markdown-to-LaTeX renderer for Swift Book source documents."""
 
+from collections.abc import Mapping
 from pathlib import Path
 
 from swift_book_pdf.core.blocks.parser import parse_blocks
@@ -21,23 +22,31 @@ from swift_book_pdf.core.markdown import (
     convert_markdown_links,
     remove_multiline_comments,
 )
+from swift_book_pdf.core.source import ChapterMetadata
 from swift_book_pdf.core.source.paths import get_file_name
 from swift_book_pdf.pdf.latex.config import LaTeXPDFConfig
 from swift_book_pdf.pdf.latex.render.blocks import convert_blocks_to_latex
 from swift_book_pdf.pdf.latex.render.chapter import generate_chapter_title
 from swift_book_pdf.pdf.latex.render.context import LaTeXRenderContext
+from swift_book_pdf.pdf.latex.render.inline import DocReferenceResolver
 
 
 class LaTeXRenderer:
     """Render Swift Book Markdown files into LaTeX body content."""
 
-    def __init__(self, config: LaTeXPDFConfig) -> None:
+    def __init__(
+        self,
+        config: LaTeXPDFConfig,
+        chapter_metadata: Mapping[str, ChapterMetadata] | None = None,
+    ) -> None:
         """Initialize a renderer for one resolved PDF build.
 
         Args:
             config: Resolved LaTeX-backed PDF build configuration.
+            chapter_metadata: Chapter metadata keyed by document key.
         """
         self.config = config
+        self.chapter_metadata = chapter_metadata or {}
 
     def render_file(self, file_path: str) -> str:
         """Render a Markdown source file as LaTeX.
@@ -105,8 +114,29 @@ class LaTeXRenderer:
                 appearance=self.config.doc_config.appearance,
                 main_font=self.config.latex_config.font_config.main_font,
                 body_font_size=self.config.doc_config.font_size,
+                doc_references=self._doc_reference_resolver(file_name),
             ),
         )
         latex_lines.extend(body_latex)
-        latex_lines.append("}\n\\newpage\n")
+        latex_lines.append("}\n\\newpage")
         return latex_lines
+
+    def _doc_reference_resolver(
+        self,
+        file_name: str,
+    ) -> DocReferenceResolver | None:
+        """Build a subset reference resolver for the current file.
+
+        Args:
+            file_name: Lowercase document key used for labels.
+
+        Returns:
+            Resolver for single-chapter builds, otherwise `None`.
+        """
+        selection = self.config.content_selection
+        if selection.only_chapter is None:
+            return None
+        return DocReferenceResolver(
+            chapter_metadata=self.chapter_metadata,
+            live_reference_prefixes=frozenset({file_name}),
+        )

--- a/tests/pdf/latex/test_code_blocks.py
+++ b/tests/pdf/latex/test_code_blocks.py
@@ -31,7 +31,7 @@ def test_convert_code_block_preserves_percent_for_minted() -> None:
 def test_convert_nested_code_block_preserves_percent_for_minted() -> None:
     block = CodeBlock(lines=["-9 % 4 // equals -1"])
 
-    rendered = convert_nested_block(block, RenderingMode.PRINT)
+    rendered = convert_nested_block(block, _render_context())
 
     assert "-9 % 4 // equals -1" in rendered
     assert r"\%" not in rendered


### PR DESCRIPTION
- Add new `--only-toc` flag to `swift-book-pdf` to generate only the table of contents.
- Add new `--only-chapter` flag to `swift-book-pdf` to generate a single chapter by DocC tag (`<doc:TheBasics>`) or file stem (`TheBasics`).

Resolves #141 