### PR TITLE
feat(highlight): use swift-docc-render overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Render Swift code blocks in generated PDF and EPUB output with the new `swift-book-swift` lexer for syntax highlighting that more closely matches Swift Book examples and Highlight.js behavior.
 - Add syntax colors for inserted and deleted code tokens in the generated PDF light and dark code styles.
 - Add Highlight.js attribution and BSD 3-Clause license text to the third-party notices.
+- Apply Swift-DocC-Render's Swift grammar overrides when highlighting Swift code.
 
 ### Fixed
 - Fix an issue where the header text in the generated PDF document could be misaligned between odd and even pages.
+- Fix an issue where Swift property scopes and unknown Highlight.js scopes could receive unsupported token styling instead of falling back to normal code text.
+- Fix an issue where multiline string escaped-newline continuations in Swift code could be highlighted differently from Swift-DocC-Render in generated HTML and Pygments tokens.
 
 ### Removed
 - Remove the bundled `Swift_logo_color_epub.png` asset, which is no longer referenced by the new SVG-based cover layout.
@@ -38,7 +41,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Centralize bundled asset paths and move covers, fonts, icons, notices, and Swift logo assets into domain-specific asset directories.
 - Expand focused test coverage for CLI wiring, PDF config and engine behavior, LaTeX font handling, EPUB package generation, cover variants, notices, Markdown transforms, and rendered output.
 - Add Swift lexer fixture coverage for attributes, availability annotations, declarations, keywords, numbers, operators, ownership modifiers, regex literals, strings, SwiftUI snippets, tuples, and type definitions.
-- Add an external Swift Book corpus parity test against the latest Highlight.js Swift grammar in CI.
+- Add Swift-DocC-Render-derived tests for custom Swift grammar overrides and syntax-highlighting behavior.
+- Add an external Swift Book corpus parity test against Swift-DocC-Render's pinned Highlight.js version and custom Swift grammar override in CI.
 
 ## [2.6.0] - 2026-04-22
 ### Added

--- a/src/swift_book_pdf/lexer/docc.py
+++ b/src/swift_book_pdf/lexer/docc.py
@@ -1,0 +1,100 @@
+# Copyright 2026 Evangelos Kassos
+#
+# Portions derived from swift-docc-render:
+#   Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
+#   Licensed under Apache License v2.0 with Runtime Library Exception
+#
+#   See https://swift.org/LICENSE.txt for details.
+#   The Swift project authors are credited at https://swift.org/CONTRIBUTORS.txt.
+#   See THIRD-PARTY-NOTICES.txt for details.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Swift-DocC-Render-specific Swift lexer adjustments."""
+
+from __future__ import annotations
+
+from swift_book_pdf.lexer.swift import Mode, build_language
+
+
+def build_docc_render_language() -> Mode:
+    r"""Build Swift-DocC-Render's Swift grammar variant.
+
+    Start from this package's port of highlight.js Swift and apply DocC
+    Render's multiline-string escaped-newline override. DocC Render's older
+    class-declaration override is already represented by the current grammar:
+    ``class func`` and ``class var`` have dedicated modes, and type
+    declarations require an identifier after the declaration keyword.
+
+    Returns:
+        Highlight.js mode tree for DocC-rendered Swift code blocks.
+    """
+    language = build_language()
+    _override_multiline_string_escaped_newline(language)
+    return language
+
+
+def _override_multiline_string_escaped_newline(language: Mode) -> None:
+    """Replace escaped-newline submodes in multiline string variants.
+
+    Args:
+        language: Swift highlight.js mode tree to mutate.
+    """
+    contains = language.get("contains")
+    if not isinstance(contains, list):
+        return
+    string_mode = next(
+        (
+            mode
+            for mode in contains
+            if isinstance(mode, dict) and mode.get("className") == "string"
+        ),
+        None,
+    )
+    if not isinstance(string_mode, dict):
+        return
+    variants = string_mode.get("variants")
+    if not isinstance(variants, list):
+        return
+    for variant in variants:
+        if not isinstance(variant, dict):
+            continue
+        submodes = variant.get("contains")
+        if not isinstance(submodes, list):
+            continue
+        for index, mode in enumerate(submodes):
+            if _is_escaped_newline_mode(mode):
+                submodes[index] = {
+                    "className": "subst",
+                    "begin": r"\\#{0,3}",
+                    "end": r"[\t ]*(?:[\r\n]|\r\n)",
+                    "excludeEnd": True,
+                }
+
+
+def _is_escaped_newline_mode(mode: object) -> bool:
+    """Return whether a submode matches Swift-DocC-Render's source check."""
+    if not isinstance(mode, dict):
+        return False
+    if mode.get("className") != "subst":
+        return False
+    match = mode.get("match")
+    if match is None:
+        return False
+    match_str = str(match)
+    return match_str.startswith("\\") and match_str.endswith(
+        r"[\t ]*(?:[\r\n]|\r\n)"
+    )
+
+
+__all__ = ["build_docc_render_language"]

--- a/src/swift_book_pdf/lexer/markup.py
+++ b/src/swift_book_pdf/lexer/markup.py
@@ -21,8 +21,8 @@
 
 from __future__ import annotations
 
+from swift_book_pdf.lexer.docc import build_docc_render_language
 from swift_book_pdf.lexer.engine import Node, TokenTreeEmitter, highlight
-from swift_book_pdf.lexer.swift import build_language
 
 CLASS_PREFIX = "hljs-"
 SPAN_CLOSE = "</span>"
@@ -155,6 +155,6 @@ def highlight_swift(code: str) -> str:
     Returns:
         Inner HTML only, without wrapping `pre` or `code` elements.
     """
-    language = build_language()
+    language = build_docc_render_language()
     emitter = highlight(language, code)
     return render(emitter)

--- a/src/swift_book_pdf/lexer/swift.py
+++ b/src/swift_book_pdf/lexer/swift.py
@@ -679,7 +679,7 @@ _SCOPE_TO_TOKEN: dict[str, _TokenType] = {
     "variable": Token.Text,
     "meta": Keyword,
     "params": Name.Class,
-    "property": Name.Attribute,
+    "property": Token.Text,
     "identifier": Token.Text,
 }
 
@@ -696,7 +696,7 @@ def _scope_to_token(scope: str | None) -> _TokenType:
     if not scope:
         return Token.Text
     first = scope.split(".")[0]
-    return _SCOPE_TO_TOKEN.get(first, Token)
+    return _SCOPE_TO_TOKEN.get(first, Token.Text)
 
 
 class SwiftLexer(Lexer):
@@ -725,7 +725,9 @@ class SwiftLexer(Lexer):
             Tuples containing character offset, Pygments token type, and token
             text.
         """
-        language = build_language()
+        from swift_book_pdf.lexer.docc import build_docc_render_language
+
+        language = build_docc_render_language()
         emitter = highlight(language, text)
         pos = 0
         for token_type, value in _flatten(emitter.root, None):

--- a/tests/lexer/swift/base.py
+++ b/tests/lexer/swift/base.py
@@ -14,17 +14,11 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-
-from tests.lexer.swift.base import highlight_base_swift
-
-_FIXTURES = Path(__file__).parent / "fixtures"
+from swift_book_pdf.lexer.engine import highlight
+from swift_book_pdf.lexer.markup import render
+from swift_book_pdf.lexer.swift import build_language
 
 
-def test_operators() -> None:
-    source = (_FIXTURES / "operators.txt").read_text()
-    expected = (_FIXTURES / "operators.expect.txt").read_text()
-    # highlight.js's markup test harness compares trimmed output on
-    # both sides; some .expect.txt fixtures were saved with an extra
-    # or missing trailing newline, so normalize it before comparing.
-    assert highlight_base_swift(source).rstrip("\n") == expected.rstrip("\n")
+def highlight_base_swift(code: str) -> str:
+    """Highlight Swift with the unmodified highlight.js Swift grammar."""
+    return render(highlight(build_language(), code))

--- a/tests/lexer/swift/test_attributes.py
+++ b/tests/lexer/swift/test_attributes.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from swift_book_pdf.lexer import highlight_swift
+from tests.lexer.swift.base import highlight_base_swift
 
 _FIXTURES = Path(__file__).parent / "fixtures"
 
@@ -27,4 +27,4 @@ def test_attributes() -> None:
     # highlight.js's markup test harness compares trimmed output on
     # both sides; some .expect.txt fixtures were saved with an extra
     # or missing trailing newline, so normalize it before comparing.
-    assert highlight_swift(source).rstrip("\n") == expected.rstrip("\n")
+    assert highlight_base_swift(source).rstrip("\n") == expected.rstrip("\n")

--- a/tests/lexer/swift/test_availability.py
+++ b/tests/lexer/swift/test_availability.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from swift_book_pdf.lexer import highlight_swift
+from tests.lexer.swift.base import highlight_base_swift
 
 _FIXTURES = Path(__file__).parent / "fixtures"
 
@@ -27,4 +27,4 @@ def test_availability() -> None:
     # highlight.js's markup test harness compares trimmed output on
     # both sides; some .expect.txt fixtures were saved with an extra
     # or missing trailing newline, so normalize it before comparing.
-    assert highlight_swift(source).rstrip("\n") == expected.rstrip("\n")
+    assert highlight_base_swift(source).rstrip("\n") == expected.rstrip("\n")

--- a/tests/lexer/swift/test_class_func_var.py
+++ b/tests/lexer/swift/test_class_func_var.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from swift_book_pdf.lexer import highlight_swift
+from tests.lexer.swift.base import highlight_base_swift
 
 _FIXTURES = Path(__file__).parent / "fixtures"
 
@@ -27,4 +27,4 @@ def test_class_func_var() -> None:
     # highlight.js's markup test harness compares trimmed output on
     # both sides; some .expect.txt fixtures were saved with an extra
     # or missing trailing newline, so normalize it before comparing.
-    assert highlight_swift(source).rstrip("\n") == expected.rstrip("\n")
+    assert highlight_base_swift(source).rstrip("\n") == expected.rstrip("\n")

--- a/tests/lexer/swift/test_custom_highlight_lang_swift.py
+++ b/tests/lexer/swift/test_custom_highlight_lang_swift.py
@@ -1,0 +1,72 @@
+# Copyright 2026 Evangelos Kassos
+#
+# Portions derived from swift-docc-render:
+#   Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
+#   Licensed under Apache License v2.0 with Runtime Library Exception
+#
+#   See https://swift.org/LICENSE.txt for details.
+#   The Swift project authors are credited at https://swift.org/CONTRIBUTORS.txt.
+#   See THIRD-PARTY-NOTICES.txt for details.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Ports swift-docc-render's tests/unit/utils/custom-highlight-lang/swift.spec.js
+# against this package's equivalent of `swift(hljs)`,
+# `build_docc_render_language`.
+
+from __future__ import annotations
+
+import re
+
+from swift_book_pdf.lexer.docc import build_docc_render_language
+
+# The class/type declaration mode's leading `begin` regex in the current
+# highlight.js Swift grammar (highlight.js 11.10 replaced the old
+# `beginKeywords` class mode with this `TYPE_DECLARATION`).
+_TYPE_DECLARATION_BEGIN = "(struct|protocol|class|extension|enum|actor)"
+
+
+def _class_mode() -> dict:
+    """Return the class declaration mode the way swift.spec.js locates it.
+
+    Returns:
+        The mode whose array `begin` matches a class declaration.
+    """
+    language = build_docc_render_language()
+    contains = language["contains"]
+    for mode in contains:
+        if not isinstance(mode, dict):
+            continue
+        begin = mode.get("begin")
+        if (
+            isinstance(begin, list)
+            and begin
+            and re.search(begin[0], "class Foobar {")
+        ):
+            return mode
+    raise AssertionError("no class declaration mode found")
+
+
+def test_recognizes_the_distributed_keyword() -> None:
+    language = build_docc_render_language()
+    assert "distributed" in language["keywords"]["keyword"]
+
+
+def test_class_mode_does_not_have_a_begin_keywords_attribute() -> None:
+    assert "beginKeywords" not in _class_mode()
+
+
+def test_class_mode_does_have_a_begin_attribute() -> None:
+    mode = _class_mode()
+    assert isinstance(mode["begin"], list)
+    assert mode["begin"][0] == _TYPE_DECLARATION_BEGIN

--- a/tests/lexer/swift/test_distributed_actor_runtime.py
+++ b/tests/lexer/swift/test_distributed_actor_runtime.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from swift_book_pdf.lexer import highlight_swift
+from tests.lexer.swift.base import highlight_base_swift
 
 _FIXTURES = Path(__file__).parent / "fixtures"
 
@@ -27,4 +27,4 @@ def test_distributed_actor_runtime() -> None:
     # highlight.js's markup test harness compares trimmed output on
     # both sides; some .expect.txt fixtures were saved with an extra
     # or missing trailing newline, so normalize it before comparing.
-    assert highlight_swift(source).rstrip("\n") == expected.rstrip("\n")
+    assert highlight_base_swift(source).rstrip("\n") == expected.rstrip("\n")

--- a/tests/lexer/swift/test_functions.py
+++ b/tests/lexer/swift/test_functions.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from swift_book_pdf.lexer import highlight_swift
+from tests.lexer.swift.base import highlight_base_swift
 
 _FIXTURES = Path(__file__).parent / "fixtures"
 
@@ -27,4 +27,4 @@ def test_functions() -> None:
     # highlight.js's markup test harness compares trimmed output on
     # both sides; some .expect.txt fixtures were saved with an extra
     # or missing trailing newline, so normalize it before comparing.
-    assert highlight_swift(source).rstrip("\n") == expected.rstrip("\n")
+    assert highlight_base_swift(source).rstrip("\n") == expected.rstrip("\n")

--- a/tests/lexer/swift/test_identifiers.py
+++ b/tests/lexer/swift/test_identifiers.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from swift_book_pdf.lexer import highlight_swift
+from tests.lexer.swift.base import highlight_base_swift
 
 _FIXTURES = Path(__file__).parent / "fixtures"
 
@@ -27,4 +27,4 @@ def test_identifiers() -> None:
     # highlight.js's markup test harness compares trimmed output on
     # both sides; some .expect.txt fixtures were saved with an extra
     # or missing trailing newline, so normalize it before comparing.
-    assert highlight_swift(source).rstrip("\n") == expected.rstrip("\n")
+    assert highlight_base_swift(source).rstrip("\n") == expected.rstrip("\n")

--- a/tests/lexer/swift/test_keywords.py
+++ b/tests/lexer/swift/test_keywords.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from swift_book_pdf.lexer import highlight_swift
+from tests.lexer.swift.base import highlight_base_swift
 
 _FIXTURES = Path(__file__).parent / "fixtures"
 
@@ -27,4 +27,4 @@ def test_keywords() -> None:
     # highlight.js's markup test harness compares trimmed output on
     # both sides; some .expect.txt fixtures were saved with an extra
     # or missing trailing newline, so normalize it before comparing.
-    assert highlight_swift(source).rstrip("\n") == expected.rstrip("\n")
+    assert highlight_base_swift(source).rstrip("\n") == expected.rstrip("\n")

--- a/tests/lexer/swift/test_macro.py
+++ b/tests/lexer/swift/test_macro.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from swift_book_pdf.lexer import highlight_swift
+from tests.lexer.swift.base import highlight_base_swift
 
 _FIXTURES = Path(__file__).parent / "fixtures"
 
@@ -27,4 +27,4 @@ def test_macro() -> None:
     # highlight.js's markup test harness compares trimmed output on
     # both sides; some .expect.txt fixtures were saved with an extra
     # or missing trailing newline, so normalize it before comparing.
-    assert highlight_swift(source).rstrip("\n") == expected.rstrip("\n")
+    assert highlight_base_swift(source).rstrip("\n") == expected.rstrip("\n")

--- a/tests/lexer/swift/test_numbers.py
+++ b/tests/lexer/swift/test_numbers.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from swift_book_pdf.lexer import highlight_swift
+from tests.lexer.swift.base import highlight_base_swift
 
 _FIXTURES = Path(__file__).parent / "fixtures"
 
@@ -27,4 +27,4 @@ def test_numbers() -> None:
     # highlight.js's markup test harness compares trimmed output on
     # both sides; some .expect.txt fixtures were saved with an extra
     # or missing trailing newline, so normalize it before comparing.
-    assert highlight_swift(source).rstrip("\n") == expected.rstrip("\n")
+    assert highlight_base_swift(source).rstrip("\n") == expected.rstrip("\n")

--- a/tests/lexer/swift/test_operator_declarations.py
+++ b/tests/lexer/swift/test_operator_declarations.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from swift_book_pdf.lexer import highlight_swift
+from tests.lexer.swift.base import highlight_base_swift
 
 _FIXTURES = Path(__file__).parent / "fixtures"
 
@@ -27,4 +27,4 @@ def test_operator_declarations() -> None:
     # highlight.js's markup test harness compares trimmed output on
     # both sides; some .expect.txt fixtures were saved with an extra
     # or missing trailing newline, so normalize it before comparing.
-    assert highlight_swift(source).rstrip("\n") == expected.rstrip("\n")
+    assert highlight_base_swift(source).rstrip("\n") == expected.rstrip("\n")

--- a/tests/lexer/swift/test_ownership.py
+++ b/tests/lexer/swift/test_ownership.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from swift_book_pdf.lexer import highlight_swift
+from tests.lexer.swift.base import highlight_base_swift
 
 _FIXTURES = Path(__file__).parent / "fixtures"
 
@@ -27,4 +27,4 @@ def test_ownership() -> None:
     # highlight.js's markup test harness compares trimmed output on
     # both sides; some .expect.txt fixtures were saved with an extra
     # or missing trailing newline, so normalize it before comparing.
-    assert highlight_swift(source).rstrip("\n") == expected.rstrip("\n")
+    assert highlight_base_swift(source).rstrip("\n") == expected.rstrip("\n")

--- a/tests/lexer/swift/test_parameterpack.py
+++ b/tests/lexer/swift/test_parameterpack.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from swift_book_pdf.lexer import highlight_swift
+from tests.lexer.swift.base import highlight_base_swift
 
 _FIXTURES = Path(__file__).parent / "fixtures"
 
@@ -27,4 +27,4 @@ def test_parameterpack() -> None:
     # highlight.js's markup test harness compares trimmed output on
     # both sides; some .expect.txt fixtures were saved with an extra
     # or missing trailing newline, so normalize it before comparing.
-    assert highlight_swift(source).rstrip("\n") == expected.rstrip("\n")
+    assert highlight_base_swift(source).rstrip("\n") == expected.rstrip("\n")

--- a/tests/lexer/swift/test_precedencegroup.py
+++ b/tests/lexer/swift/test_precedencegroup.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from swift_book_pdf.lexer import highlight_swift
+from tests.lexer.swift.base import highlight_base_swift
 
 _FIXTURES = Path(__file__).parent / "fixtures"
 
@@ -27,4 +27,4 @@ def test_precedencegroup() -> None:
     # highlight.js's markup test harness compares trimmed output on
     # both sides; some .expect.txt fixtures were saved with an extra
     # or missing trailing newline, so normalize it before comparing.
-    assert highlight_swift(source).rstrip("\n") == expected.rstrip("\n")
+    assert highlight_base_swift(source).rstrip("\n") == expected.rstrip("\n")

--- a/tests/lexer/swift/test_regex.py
+++ b/tests/lexer/swift/test_regex.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from swift_book_pdf.lexer import highlight_swift
+from tests.lexer.swift.base import highlight_base_swift
 
 _FIXTURES = Path(__file__).parent / "fixtures"
 
@@ -27,4 +27,4 @@ def test_regex() -> None:
     # highlight.js's markup test harness compares trimmed output on
     # both sides; some .expect.txt fixtures were saved with an extra
     # or missing trailing newline, so normalize it before comparing.
-    assert highlight_swift(source).rstrip("\n") == expected.rstrip("\n")
+    assert highlight_base_swift(source).rstrip("\n") == expected.rstrip("\n")

--- a/tests/lexer/swift/test_strings.py
+++ b/tests/lexer/swift/test_strings.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from swift_book_pdf.lexer import highlight_swift
+from tests.lexer.swift.base import highlight_base_swift
 
 _FIXTURES = Path(__file__).parent / "fixtures"
 
@@ -27,4 +27,4 @@ def test_strings() -> None:
     # highlight.js's markup test harness compares trimmed output on
     # both sides; some .expect.txt fixtures were saved with an extra
     # or missing trailing newline, so normalize it before comparing.
-    assert highlight_swift(source).rstrip("\n") == expected.rstrip("\n")
+    assert highlight_base_swift(source).rstrip("\n") == expected.rstrip("\n")

--- a/tests/lexer/swift/test_swift_book_corpus_parity.py
+++ b/tests/lexer/swift/test_swift_book_corpus_parity.py
@@ -27,7 +27,9 @@ from typing import TYPE_CHECKING, Literal
 import pytest
 
 from swift_book_pdf.lexer import highlight_swift
-from swift_book_pdf.lexer.swift import SwiftLexer
+from swift_book_pdf.lexer.docc import build_docc_render_language
+from swift_book_pdf.lexer.engine import Node, highlight
+from swift_book_pdf.lexer.swift import _SCOPE_TO_TOKEN, SwiftLexer
 from swift_book_pdf.pdf.latex.preamble.styles import (
     CustomSwiftBookDarkStyle,
     CustomSwiftBookStyle,
@@ -84,12 +86,13 @@ class HighlightResult:
 
 @dataclass(frozen=True)
 class CorpusEnvironment:
-    """External repositories and latest highlight.js installation."""
+    """External repositories and the pinned highlight.js installation."""
 
     swift_book: Path
     swift_docc_render: Path
     node_package: Path
     node: str
+    highlightjs_version: str
 
 
 @pytest.fixture(scope="module")
@@ -117,25 +120,33 @@ def corpus_environment(
         destination=tmp_path / "swift-docc-render",
         git=git,
     )
-    node_package = _install_latest_highlight_js(tmp_path / "node", npm)
+    highlightjs_version = _swift_docc_render_highlightjs_version(
+        swift_docc_render
+    )
+    node_package = _install_highlight_js(
+        tmp_path / "node", npm, highlightjs_version
+    )
+    _write_swift_docc_render_override(swift_docc_render, node_package)
     return CorpusEnvironment(
         swift_book=swift_book,
         swift_docc_render=swift_docc_render,
         node_package=node_package,
         node=node,
+        highlightjs_version=highlightjs_version,
     )
 
 
-def test_swift_book_corpus_matches_latest_highlightjs_html(
+def test_swift_book_corpus_matches_swift_docc_render_html(
     corpus_environment: CorpusEnvironment,
 ) -> None:
-    """Verify the ported lexer emits the same HTML as latest highlight.js."""
+    """Verify HTML spans match Swift-DocC-Render's custom Swift highlighter."""
     blocks = _extract_swift_code_blocks(corpus_environment.swift_book)
-    highlightjs = _highlight_with_latest_highlightjs(
+    highlightjs = _highlight_with_highlightjs(
         corpus_environment,
         [block.code for block in blocks],
         class_prefix=None,
     )
+    assert highlightjs.version == corpus_environment.highlightjs_version
 
     mismatches: list[dict[str, object]] = []
     for index, (block, expected) in enumerate(
@@ -148,10 +159,44 @@ def test_swift_book_corpus_matches_latest_highlightjs_html(
             )
 
     assert mismatches == [], (
-        f"Latest highlight.js {highlightjs.version} differed from the "
-        f"ported lexer for {len(mismatches)} of {len(blocks)} Swift Book "
-        f"blocks:\n{json.dumps(mismatches[:5], indent=2)}"
+        f"highlight.js {highlightjs.version} plus swift-docc-render's "
+        f"Swift override differed from highlight_swift for "
+        f"{len(mismatches)} of {len(blocks)} Swift Book blocks:\n"
+        f"{json.dumps(mismatches[:5], indent=2)}"
     )
+
+
+def test_swift_book_corpus_token_scopes_are_mapped(
+    corpus_environment: CorpusEnvironment,
+) -> None:
+    """Verify every relevant DocC Swift token scope has a Pygments mapping."""
+    blocks = _extract_swift_code_blocks(corpus_environment.swift_book)
+    emitted_scopes = _emitted_scope_roots(blocks)
+    docc_theme = _load_docc_syntax_theme(corpus_environment.swift_docc_render)
+    docc_tokens = set(docc_theme["token_colors"])
+
+    missing_emitted_mappings = sorted(emitted_scopes - set(_SCOPE_TO_TOKEN))
+    missing_docc_mappings = sorted(docc_tokens - set(_SCOPE_TO_TOKEN))
+    assert missing_emitted_mappings == []
+    assert missing_docc_mappings == []
+
+    plain_fallback_scopes = emitted_scopes - docc_tokens
+    plain_fallback_colors = {
+        scope: {
+            "light": _style_color(
+                CustomSwiftBookStyle, _SCOPE_TO_TOKEN[scope]
+            ),
+            "dark": _style_color(
+                CustomSwiftBookDarkStyle, _SCOPE_TO_TOKEN[scope]
+            ),
+        }
+        for scope in sorted(plain_fallback_scopes)
+    }
+    assert plain_fallback_colors == {
+        "operator": {"light": "000000", "dark": "ffffff"},
+        "regexp": {"light": "000000", "dark": "ffffff"},
+        "variable": {"light": "000000", "dark": "ffffff"},
+    }
 
 
 def test_swift_book_corpus_matches_swift_docc_render_colors(
@@ -160,11 +205,12 @@ def test_swift_book_corpus_matches_swift_docc_render_colors(
     """Verify the Pygments adapter keeps current DocC syntax colors."""
     blocks = _extract_swift_code_blocks(corpus_environment.swift_book)
     docc_theme = _load_docc_syntax_theme(corpus_environment.swift_docc_render)
-    highlightjs = _highlight_with_latest_highlightjs(
+    highlightjs = _highlight_with_highlightjs(
         corpus_environment,
         [block.code for block in blocks],
         class_prefix="syntax-",
     )
+    assert highlightjs.version == corpus_environment.highlightjs_version
 
     for appearance, style in (
         ("light", CustomSwiftBookStyle),
@@ -189,7 +235,7 @@ def test_swift_book_corpus_matches_swift_docc_render_colors(
         )
 
         assert mismatches == [], (
-            f"Latest highlight.js {highlightjs.version} plus current "
+            f"highlight.js {highlightjs.version} plus current "
             f"swift-docc-render syntax colors differed from the {appearance} "
             f"Pygments adapter for {len(mismatches)} of {len(blocks)} Swift "
             f"Book blocks:\n{json.dumps(mismatches[:5], indent=2)}"
@@ -226,7 +272,24 @@ def _resolve_or_clone_repo(
     return destination
 
 
-def _install_latest_highlight_js(destination: Path, npm: str) -> Path:
+def _swift_docc_render_highlightjs_version(swift_docc_render: Path) -> str:
+    lock = swift_docc_render / "package-lock.json"
+    if lock.exists():
+        data = json.loads(lock.read_text(encoding="utf-8"))
+        package = data.get("packages", {}).get("node_modules/highlight.js", {})
+        if package.get("version"):
+            return package["version"]
+        dependency = data.get("dependencies", {}).get("highlight.js", {})
+        if dependency.get("version"):
+            return dependency["version"]
+    pytest.fail(
+        f"Could not determine the highlight.js version Swift-DocC-Render "
+        f"uses from {lock}"
+    )
+    raise AssertionError("unreachable")
+
+
+def _install_highlight_js(destination: Path, npm: str, version: str) -> Path:
     destination.mkdir()
     subprocess.run(  # noqa: S603
         [npm, "init", "-y"],
@@ -235,12 +298,50 @@ def _install_latest_highlight_js(destination: Path, npm: str) -> Path:
         stdout=subprocess.DEVNULL,
     )
     subprocess.run(  # noqa: S603
-        [npm, "install", "highlight.js@latest", "--no-audit", "--no-fund"],
+        [
+            npm,
+            "install",
+            f"highlight.js@{version}",
+            "--no-audit",
+            "--no-fund",
+        ],
         cwd=destination,
         check=True,
         stdout=subprocess.DEVNULL,
     )
     return destination
+
+
+def _write_swift_docc_render_override(
+    swift_docc_render: Path, node_package: Path
+) -> None:
+    """Stage Swift-DocC-Render's Swift override as a CommonJS module.
+
+    Args:
+        swift_docc_render: Resolved Swift-DocC-Render checkout.
+        node_package: Directory holding the pinned highlight.js install.
+    """
+    source = swift_docc_render / "src/utils/custom-highlight-lang/swift.js"
+    if not source.exists():
+        pytest.fail(f"Missing Swift-DocC-Render Swift override: {source}")
+    text = source.read_text(encoding="utf-8")
+    import_line = "import swift from 'highlight.js/lib/languages/swift';"
+    export_line = "export default function swiftOverride(hljs) {"
+    if import_line not in text or export_line not in text:
+        pytest.fail(
+            "Swift-DocC-Render Swift override no longer matches the expected "
+            "ES module shape; update the CommonJS rewrite."
+        )
+    commonjs = text.replace(
+        import_line,
+        "const swift = require('highlight.js/lib/languages/swift');",
+    ).replace(
+        export_line,
+        "module.exports = function swiftOverride(hljs) {",
+    )
+    (node_package / "swift-override.cjs").write_text(
+        commonjs, encoding="utf-8"
+    )
 
 
 def _extract_swift_code_blocks(swift_book: Path) -> list[CodeBlock]:
@@ -285,13 +386,15 @@ def _extract_swift_code_blocks(swift_book: Path) -> list[CodeBlock]:
     return blocks
 
 
-def _highlight_with_latest_highlightjs(
+def _highlight_with_highlightjs(
     corpus_environment: CorpusEnvironment,
     code_blocks: list[str],
+    *,
     class_prefix: str | None,
 ) -> HighlightResult:
     script = f"""
-const hljs = require("highlight.js");
+const hljs = require("highlight.js/lib/core");
+hljs.registerLanguage("swift", require("./swift-override.cjs"));
 const classPrefix = {json.dumps(class_prefix)};
 if (classPrefix !== null) {{
   hljs.configure({{ classPrefix }});
@@ -323,6 +426,24 @@ process.stdin.on("end", () => {{
         version=payload["version"],
         html=list(payload["html"]),
     )
+
+
+def _emitted_scope_roots(blocks: list[CodeBlock]) -> set[str]:
+    language = build_docc_render_language()
+    scopes: set[str] = set()
+    for block in blocks:
+        emitter = highlight(language, block.code)
+        _collect_scope_roots(emitter.root, scopes)
+    return scopes
+
+
+def _collect_scope_roots(node: Node | str, scopes: set[str]) -> None:
+    if isinstance(node, str):
+        return
+    if node.scope:
+        scopes.add(node.scope.split(".")[0])
+    for child in node.children:
+        _collect_scope_roots(child, scopes)
 
 
 def _load_docc_syntax_theme(

--- a/tests/lexer/swift/test_swiftui.py
+++ b/tests/lexer/swift/test_swiftui.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from swift_book_pdf.lexer import highlight_swift
+from tests.lexer.swift.base import highlight_base_swift
 
 _FIXTURES = Path(__file__).parent / "fixtures"
 
@@ -27,4 +27,4 @@ def test_swiftui() -> None:
     # highlight.js's markup test harness compares trimmed output on
     # both sides; some .expect.txt fixtures were saved with an extra
     # or missing trailing newline, so normalize it before comparing.
-    assert highlight_swift(source).rstrip("\n") == expected.rstrip("\n")
+    assert highlight_base_swift(source).rstrip("\n") == expected.rstrip("\n")

--- a/tests/lexer/swift/test_syntax_highlight.py
+++ b/tests/lexer/swift/test_syntax_highlight.py
@@ -1,0 +1,162 @@
+# Copyright 2026 Evangelos Kassos
+#
+# Portions derived from swift-docc-render:
+#   Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
+#   Licensed under Apache License v2.0 with Runtime Library Exception
+#
+#   See https://swift.org/LICENSE.txt for details.
+#   The Swift project authors are credited at https://swift.org/CONTRIBUTORS.txt.
+#   See THIRD-PARTY-NOTICES.txt for details.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Ports the Swift-applicable cases of swift-docc-render's
+# tests/unit/utils/syntax-highlight.spec.js. The spec exercises two outputs:
+# the raw `highlight()` HTML and the line-wrapped `highlightContent()` form.
+# This package mirrors the first with `highlight_swift` (markup layer) and the
+# second with `SwiftLexer`, whose per-line token stream feeds the LaTeX/minted
+# renderer instead of HTML line wrapping.
+
+from __future__ import annotations
+
+from pygments.token import String
+
+from swift_book_pdf.lexer import SwiftLexer, highlight_swift
+
+
+def _tokens(code: str) -> list[tuple[object, str]]:
+    """Tokenize Swift source through the DocC Render Pygments adapter.
+
+    Args:
+        code: Swift source text.
+
+    Returns:
+        List of (token type, value) pairs, in order.
+    """
+    return [
+        (token, value)
+        for _position, token, value in SwiftLexer().get_tokens_unprocessed(
+            code
+        )
+    ]
+
+
+def test_does_nothing_to_single_row_syntax() -> None:
+    source = "\n".join(
+        [
+            'let name = "Rosa"',
+            r'let personalizedGreeting = "Welcome, \(name)!"',
+        ]
+    )
+    expected = "\n".join(
+        [
+            '<span class="hljs-keyword">let</span> name '
+            '<span class="hljs-operator">=</span> '
+            '<span class="hljs-string">&quot;Rosa&quot;</span>',
+            '<span class="hljs-keyword">let</span> personalizedGreeting '
+            '<span class="hljs-operator">=</span> '
+            '<span class="hljs-string">&quot;Welcome, '
+            r'<span class="hljs-subst">\(name)</span>!&quot;</span>',
+        ]
+    )
+    assert highlight_swift(source) == expected
+
+
+def test_tokenizes_swift_class_functions_correctly() -> None:
+    source = "class func foo() async throws -> [Bar]"
+    expected = (
+        '<span class="hljs-keyword">class</span> '
+        '<span class="hljs-keyword">func</span> '
+        '<span class="hljs-title function_">foo</span>() '
+        '<span class="hljs-keyword">async</span> '
+        '<span class="hljs-keyword">throws</span> -&gt; '
+        '[<span class="hljs-type">Bar</span>]'
+    )
+    assert highlight_swift(source) == expected
+
+
+def test_does_not_tokenize_swift_keywords_inside_words() -> None:
+    source = "\n".join(
+        [
+            "var protocolMock = true  // 'protocol' is not highlighted",
+            "var myenum = true  // 'enum' is not highlighted",
+            "if FooConfig.supportsReconstruction(.someClassification) {",
+            "    configuration.fooReconstruction = .someprotocolextensionclass",
+            "}",
+        ]
+    )
+    expected = "\n".join(
+        [
+            '<span class="hljs-keyword">var</span> protocolMock '
+            '<span class="hljs-operator">=</span> '
+            '<span class="hljs-literal">true</span>  '
+            '<span class="hljs-comment">// &#x27;protocol&#x27; is not '
+            "highlighted</span>",
+            '<span class="hljs-keyword">var</span> myenum '
+            '<span class="hljs-operator">=</span> '
+            '<span class="hljs-literal">true</span>  '
+            '<span class="hljs-comment">// &#x27;enum&#x27; is not '
+            "highlighted</span>",
+            '<span class="hljs-keyword">if</span> '
+            '<span class="hljs-type">FooConfig</span>'
+            ".supportsReconstruction(.someClassification) {",
+            "    configuration.fooReconstruction "
+            '<span class="hljs-operator">=</span> '
+            ".someprotocolextensionclass",
+            "}",
+        ]
+    )
+    assert highlight_swift(source) == expected
+
+
+def test_wraps_multiline_string_blocks_in_string_scope() -> None:
+    source = "\n".join(
+        [
+            'let banner = """',
+            "          __,",
+            "         (           o  /) _/_",
+            "          `.  , , , ,  //  /",
+            "        (___)(_(_/_(_ //_ (__",
+            "                     /)",
+            "                    (/",
+            '        """',
+        ]
+    )
+    literal_start = source.index('"""')
+    offset = 0
+    for token, value in _tokens(source):
+        if offset >= literal_start:
+            assert token in String, (token, value)
+        offset += len(value)
+
+
+def test_keeps_escaped_newline_tokens_on_the_same_line() -> None:
+    source = "\n".join(
+        [
+            'let multiline = """',
+            "a \\",
+            "b",
+            "",
+            "c \\",
+            "d",
+            '"""',
+        ]
+    )
+    tokens = _tokens(source)
+    rendered = "".join(value for _token, value in tokens)
+    assert rendered == source
+    # The escaped-newline override emits the backslash as its own token and
+    # leaves the newline with the surrounding string, so no single token spans
+    # the line continuation.
+    assert any(value == "\\" for _token, value in tokens)
+    assert not any("\\" in value and "\n" in value for _token, value in tokens)

--- a/tests/lexer/swift/test_tuples.py
+++ b/tests/lexer/swift/test_tuples.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from swift_book_pdf.lexer import highlight_swift
+from tests.lexer.swift.base import highlight_base_swift
 
 _FIXTURES = Path(__file__).parent / "fixtures"
 
@@ -27,4 +27,4 @@ def test_tuples() -> None:
     # highlight.js's markup test harness compares trimmed output on
     # both sides; some .expect.txt fixtures were saved with an extra
     # or missing trailing newline, so normalize it before comparing.
-    assert highlight_swift(source).rstrip("\n") == expected.rstrip("\n")
+    assert highlight_base_swift(source).rstrip("\n") == expected.rstrip("\n")

--- a/tests/lexer/swift/test_type_definition.py
+++ b/tests/lexer/swift/test_type_definition.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from swift_book_pdf.lexer import highlight_swift
+from tests.lexer.swift.base import highlight_base_swift
 
 _FIXTURES = Path(__file__).parent / "fixtures"
 
@@ -27,4 +27,4 @@ def test_type_definition() -> None:
     # highlight.js's markup test harness compares trimmed output on
     # both sides; some .expect.txt fixtures were saved with an extra
     # or missing trailing newline, so normalize it before comparing.
-    assert highlight_swift(source).rstrip("\n") == expected.rstrip("\n")
+    assert highlight_base_swift(source).rstrip("\n") == expected.rstrip("\n")

--- a/tests/lexer/swift/test_types.py
+++ b/tests/lexer/swift/test_types.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from swift_book_pdf.lexer import highlight_swift
+from tests.lexer.swift.base import highlight_base_swift
 
 _FIXTURES = Path(__file__).parent / "fixtures"
 
@@ -27,4 +27,4 @@ def test_types() -> None:
     # highlight.js's markup test harness compares trimmed output on
     # both sides; some .expect.txt fixtures were saved with an extra
     # or missing trailing newline, so normalize it before comparing.
-    assert highlight_swift(source).rstrip("\n") == expected.rstrip("\n")
+    assert highlight_base_swift(source).rstrip("\n") == expected.rstrip("\n")


### PR DESCRIPTION
- Apply Swift-DocC-Render's Swift grammar overrides when highlighting Swift code.
- Fix an issue where Swift property scopes and unknown Highlight.js scopes could receive unsupported token styling instead of falling back to normal code text.
- Fix an issue where multiline string escaped-newline continuations in Swift code could be highlighted differently from Swift-DocC-Render in generated HTML and Pygments tokens.
- Add Swift-DocC-Render-derived tests for custom Swift grammar overrides and syntax-highlighting behavior.
- Add an external Swift Book corpus parity test against Swift-DocC-Render's pinned Highlight.js version and custom Swift grammar override in CI.

Resolves #144.