### PR TITLE
feat(pdf): add opportunities for inline code wrapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add new `--save-intermediates` flag to `swift-book-pdf` to save the build intermediates to a user-provided directory.
 - Add new `--only-toc` flag to `swift-book-pdf` to generate only the table of contents.
 - Add new `--only-chapter` flag to `swift-book-pdf` to generate a single chapter by DocC tag (`<doc:TheBasics>`) or file stem (`TheBasics`).
+- Add Swift-DocC-Render-compatible word break opportunities to generated PDF inline code spans.
 
 ### Changed
 - Redesign generated EPUB cover artwork and rendered cover text for release and beta editions, with new templates, edition-specific colors, and adjusted version-label spacing and positioning.

--- a/src/swift_book_pdf/pdf/latex/render/code_spans.py
+++ b/src/swift_book_pdf/pdf/latex/render/code_spans.py
@@ -1,5 +1,13 @@
 # Copyright 2026 Evangelos Kassos
 #
+# Portions derived from swift-docc-render:
+#   Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
+#   Licensed under Apache License v2.0 with Runtime Library Exception
+#
+#   See https://swift.org/LICENSE.txt for details.
+#   The Swift project authors are credited at https://swift.org/CONTRIBUTORS.txt.
+#   See THIRD-PARTY-NOTICES.txt for details.
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -17,6 +25,8 @@
 import re
 
 from swift_book_pdf.pdf.latex.render.escaping import escape_texttt
+
+DOCC_WORD_BREAK = r"\allowbreak{}"
 
 
 def convert_inline_code(text: str) -> str:
@@ -40,9 +50,7 @@ def convert_inline_code(text: str) -> str:
             Placeholder token for the rendered code span.
         """
         inner = match.group(1)
-        processed = (
-            r"{\CodeStyle \texttt{" + escape_texttt(inner).strip() + "}}"
-        )
+        processed = _render_code_voice(inner)
         token = f"@@DOUBLE{len(double_placeholder)}@@"
         double_placeholder[token] = processed
         return token
@@ -59,7 +67,7 @@ def convert_inline_code(text: str) -> str:
             Rendered LaTeX inline code span.
         """
         inner = match.group(1)
-        return r"{\CodeStyle \texttt{" + escape_texttt(inner).strip() + "}}"
+        return _render_code_voice(inner)
 
     text = re.sub(r"(?<!\\)`(.*?)`", repl_single, text)
 
@@ -67,3 +75,62 @@ def convert_inline_code(text: str) -> str:
         text = text.replace(token, replacement)
 
     return text
+
+
+def _render_code_voice(text: str) -> str:
+    """Render a Markdown code span as a DocC `codeVoice` LaTeX span.
+
+    Args:
+        text: Raw inline-code text.
+
+    Returns:
+        LaTeX for the inline-code span.
+    """
+    return (
+        r"{\CodeStyle \texttt{"
+        + _escape_texttt_with_word_breaks(text.strip())
+        + "}}"
+    )
+
+
+def _escape_texttt_with_word_breaks(text: str) -> str:
+    """Escape inline code and preserve DocC Render word-break hints.
+
+    DocC Render's `CodeVoice` component wraps inline code in `WordBreak`, whose
+    default boundary pattern inserts break opportunities between lower/uppercase
+    pairs, after colons, before dots, and before underscores.
+
+    Args:
+        text: Raw inline-code text.
+
+    Returns:
+        Escaped inline-code text with LaTeX break opportunities.
+    """
+    pieces: list[str] = []
+    start = 0
+
+    for boundary in _docc_word_break_boundaries(text):
+        pieces.append(escape_texttt(text[start:boundary]))
+        pieces.append(DOCC_WORD_BREAK)
+        start = boundary
+
+    pieces.append(escape_texttt(text[start:]))
+    return "".join(pieces)
+
+
+def _docc_word_break_boundaries(text: str) -> list[int]:
+    """Return the raw-string indexes where DocC Render inserts `<wbr>`.
+
+    Args:
+        text: Raw inline-code text.
+
+    Returns:
+        Character indexes after which a break opportunity should be inserted.
+    """
+    return [
+        match.start() + 1
+        for match in re.finditer(
+            r"([a-z](?=[A-Z])|(:)\w|\w(?=[._]\w))",
+            text,
+        )
+    ]


### PR DESCRIPTION
Add Swift-DocC-Render-compatible word break opportunities to generated PDF inline code spans.

Closes #147 