### PR TITLE
feat(pdf): generalize color tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add syntax colors for inserted and deleted code tokens in the generated PDF light and dark code styles.
 - Add Highlight.js attribution and BSD 3-Clause license text to the third-party notices.
 - Apply Swift-DocC-Render's Swift grammar overrides when highlighting Swift code.
+- Align generated PDF LaTeX colors with Swift-DocC-Render CSS color tokens for page backgrounds, chapter heroes, links, tables, code blocks, and aside notes.
 
 ### Fixed
 - Fix an issue where the header text in the generated PDF document could be misaligned between odd and even pages.

--- a/src/swift_book_pdf/pdf/latex/preamble/template.py
+++ b/src/swift_book_pdf/pdf/latex/preamble/template.py
@@ -74,19 +74,20 @@ def build_preamble_substitutions(
         config.doc_config.gutter,
     )
     return {
-        "background": colors.background,
-        "text": colors.text,
-        "header_background": colors.header_background,
-        "header_text": colors.header_text,
-        "hero_background": colors.hero_background,
-        "hero_text": colors.hero_text,
-        "link": colors.link,
-        "aside_background": colors.aside_background,
-        "aside_text": colors.aside_text,
-        "aside_border": colors.aside_border,
-        "table_border": colors.table_border,
-        "code_border": colors.code_border,
-        "code_background": colors.code_background,
+        "color_text_background": colors.color_text_background,
+        "color_text": colors.color_text,
+        "color_article_background": colors.color_article_background,
+        "color_header_footer_background": (
+            colors.color_header_footer_background
+        ),
+        "color_header_footer_text": colors.color_header_footer_text,
+        "color_link": colors.color_link,
+        "color_grid": colors.color_grid,
+        "color_code_background": colors.color_code_background,
+        "color_code_plain": colors.color_code_plain,
+        "color_aside_note_background": colors.color_aside_note_background,
+        "color_aside_note_border": colors.color_aside_note_border,
+        "color_aside_note": colors.color_aside_note,
         "code_style": colors.code_style,
         "geometry_opts": get_geometry_opts(
             config.doc_config.paper_size,

--- a/src/swift_book_pdf/pdf/latex/render/tables.py
+++ b/src/swift_book_pdf/pdf/latex/render/tables.py
@@ -50,7 +50,7 @@ def convert_table_block(
     parskip = get_spacing("parskip", body_font_size)
     baselineskip = get_spacing("baselineskip_table", body_font_size)
     output = [
-        "\\begin{table}[H]\n\\centering\n\\setlength{\\tymin}{1in}\\arrayrulecolor{table_border}\n\\renewcommand{\\arraystretch}{1.5}\n\\mainFontWithFallback{"
+        "\\begin{table}[H]\n\\centering\n\\setlength{\\tymin}{1in}\\arrayrulecolor{color_grid}\n\\renewcommand{\\arraystretch}{1.5}\n\\mainFontWithFallback{"
         + main_font
         + "}\\fontsize{"
         + font_size

--- a/src/swift_book_pdf/pdf/latex/styling/colors.py
+++ b/src/swift_book_pdf/pdf/latex/styling/colors.py
@@ -1,5 +1,13 @@
 # Copyright 2025 Evangelos Kassos
 #
+# Portions derived from swift-docc-render:
+#   Copyright (c) 2021-2025 Apple Inc. and the Swift project authors
+#   Licensed under Apache License v2.0 with Runtime Library Exception
+#
+#   See https://swift.org/LICENSE.txt for details.
+#   The Swift project authors are credited at https://swift.org/CONTRIBUTORS.txt.
+#   See THIRD-PARTY-NOTICES.txt for details.
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -21,46 +29,43 @@ from swift_book_pdf.pdf.config import Appearance, RenderingMode
 
 @dataclass(frozen=True)
 class DocumentColors:
-    """RGB color substitutions used by the LaTeX preamble."""
+    """DocC Render CSS colors used by the LaTeX preamble."""
 
-    background: str
-    """Page background color."""
+    color_text_background: str
+    """DocC `--color-text-background` color."""
 
-    text: str
-    """Primary text color."""
+    color_text: str
+    """DocC `--color-text` color."""
 
-    header_background: str
-    """Running header background color."""
+    color_article_background: str
+    """DocC `--color-article-background` color."""
 
-    header_text: str
-    """Running header text color."""
+    color_header_footer_background: str
+    """PDF running header and footer background color."""
 
-    hero_background: str
-    """Chapter hero background color."""
+    color_header_footer_text: str
+    """PDF running header and footer text color."""
 
-    hero_text: str
-    """Chapter hero text color."""
+    color_link: str
+    """DocC `--color-link` color."""
 
-    link: str
-    """Hyperlink text color."""
+    color_grid: str
+    """DocC `--color-grid` color."""
 
-    aside_background: str
-    """Aside box background color."""
+    color_code_background: str
+    """DocC `--color-code-background` color."""
 
-    aside_border: str
-    """Aside box border color."""
+    color_code_plain: str
+    """DocC `--color-code-plain` color."""
 
-    aside_text: str
-    """Aside box text color."""
+    color_aside_note_background: str
+    """DocC `--color-aside-note-background` color."""
 
-    table_border: str
-    """Table rule color."""
+    color_aside_note_border: str
+    """DocC `--color-aside-note-border` color."""
 
-    code_border: str
-    """Code box border color."""
-
-    code_background: str
-    """Code box background color."""
+    color_aside_note: str
+    """DocC `--color-aside-note` color."""
 
     code_style: str
     """Pygments style name for code highlighting."""
@@ -101,21 +106,20 @@ def light_colors(rendering_mode: RenderingMode) -> DocumentColors:
         Light-mode document colors.
     """
     return DocumentColors(
-        background="255, 255, 255",
-        text="0, 0, 0",
-        header_background="51, 51, 51",
-        header_text="255, 255, 255",
-        hero_background="240, 240, 240",
-        hero_text="0, 0, 0",
-        link="51, 102, 255"
+        color_text_background="255, 255, 255",
+        color_text="0, 0, 0",
+        color_article_background="240, 240, 240",
+        color_header_footer_background="51, 51, 51",
+        color_header_footer_text="255, 255, 255",
+        color_link="51, 102, 255"
         if rendering_mode == RenderingMode.DIGITAL
         else "0, 0, 0",
-        aside_background="245, 245, 245",
-        aside_text="0, 0, 0",
-        aside_border="102, 102, 102",
-        table_border="240, 240, 240",
-        code_border="204, 204, 204",
-        code_background="247, 247, 247",
+        color_grid="204, 204, 204",
+        color_code_background="247, 247, 247",
+        color_code_plain="0, 0, 0",
+        color_aside_note_background="245, 245, 245",
+        color_aside_note_border="102, 102, 102",
+        color_aside_note="0, 0, 0",
         code_style="swift_book_style",
     )
 
@@ -130,20 +134,19 @@ def dark_colors(rendering_mode: RenderingMode) -> DocumentColors:
         Dark-mode document colors.
     """
     return DocumentColors(
-        background="0, 0, 0",
-        text="255, 255, 255",
-        header_background="51, 51, 51",
-        header_text="255, 255, 255",
-        hero_background="51, 51, 51",
-        hero_text="255, 255, 255",
-        link="0, 153, 255"
+        color_text_background="0, 0, 0",
+        color_text="255, 255, 255",
+        color_article_background="42, 42, 42",
+        color_header_footer_background="51, 51, 51",
+        color_header_footer_text="255, 255, 255",
+        color_link="0, 153, 255"
         if rendering_mode == RenderingMode.DIGITAL
         else "255, 255, 255",
-        aside_background="34, 34, 34",
-        aside_text="255, 255, 255",
-        aside_border="176, 176, 176",
-        table_border="66, 66, 66",
-        code_border="87, 87, 87",
-        code_background="22, 22, 22",
+        color_grid="87, 87, 87",
+        color_code_background="22, 22, 22",
+        color_code_plain="255, 255, 255",
+        color_aside_note_background="34, 34, 34",
+        color_aside_note_border="176, 176, 176",
+        color_aside_note="255, 255, 255",
         code_style="swift_book_dark_style",
     )

--- a/src/swift_book_pdf/pdf/latex/templates/header_footer_hero_no_gutter.tex
+++ b/src/swift_book_pdf/pdf/latex/templates/header_footer_hero_no_gutter.tex
@@ -1,22 +1,22 @@
 \fancyhead{%
 \global\AtPageToptrue%
 \begin{tikzpicture}[remember picture, overlay]
-  \fill[header_background] ([yshift=-0.5in]current page.north west)
+  \fill[color_header_footer_background] ([yshift=-0.5in]current page.north west)
   rectangle ([yshift=-0.9in]current page.north east);
 
-  \node[anchor=base east,white] at ([yshift=-0.764in,xshift=-0.7in]current page.north east) {
-    \scalebox{1.10}[1]{\headerFontWithFallback{$header_footer_font}{LetterSpace=-3.5} \fontsize{13pt}{0pt}\selectfont \customheader}
+  \node[anchor=base east] at ([yshift=-0.764in,xshift=-0.7in]current page.north east) {
+    \scalebox{1.10}[1]{\headerFontWithFallback{$header_footer_font}{LetterSpace=-3.5} \fontsize{13bp}{0bp}\selectfont \customheader}
   };
 \end{tikzpicture}%
 }
 
 \fancyfoot{%
 \begin{tikzpicture}[remember picture, overlay]
-\fill[header_background] ([yshift=0.5in]current page.south west)
+\fill[color_header_footer_background] ([yshift=0.5in]current page.south west)
  rectangle ([yshift=0.9in]current page.south east);
 
-\node[anchor=east,white] at ([yshift=0.7in,xshift=-0.7in]current page.south east) {
-  \headerFontWithFallback{$header_footer_font}{} \fontsize{13pt}{0pt}\selectfont \thepage
+\node[anchor=east] at ([yshift=0.7in,xshift=-0.7in]current page.south east) {
+  \headerFontWithFallback{$header_footer_font}{} \fontsize{13bp}{0bp}\selectfont \thepage
 };
 \end{tikzpicture}%
 }
@@ -25,11 +25,11 @@
   \fancyhf{}
   \fancyfoot{%
   \begin{tikzpicture}[remember picture, overlay]
-  \fill[header_background] ([yshift=0.5in]current page.south west)
+  \fill[color_header_footer_background] ([yshift=0.5in]current page.south west)
    rectangle ([yshift=0.9in]current page.south east);
 
-  \node[anchor=east,white] at ([yshift=0.7in,xshift=-0.7in]current page.south east) {
-    \headerFontWithFallback{$header_footer_font}{} \fontsize{13pt}{0pt}\selectfont \thepage
+  \node[anchor=east] at ([yshift=0.7in,xshift=-0.7in]current page.south east) {
+    \headerFontWithFallback{$header_footer_font}{} \fontsize{13bp}{0bp}\selectfont \thepage
   };
   \end{tikzpicture}%
   }
@@ -37,11 +37,11 @@
 
 \newcommand{\HeroBox}[3]{%
   \hspace*{-2in}
-  \fcolorbox{hero_background}{hero_background}{%
+  \fcolorbox{color_article_background}{color_article_background}{%
     \begin{minipage}{\dimexpr\textwidth+2.3in\relax}
       \hspace{1.9in}
       \begin{minipage}[t]{0.7\textwidth}
-        \color{hero_text}
+        \color{color_text}
         \vspace*{${spacing_hero_top}}
         \TitleSection{#1}{#2}  % Title
         {\SubtitleStyle #3\par}  % Subtitle

--- a/src/swift_book_pdf/pdf/latex/templates/header_footer_hero_with_gutter.tex
+++ b/src/swift_book_pdf/pdf/latex/templates/header_footer_hero_with_gutter.tex
@@ -1,11 +1,11 @@
 \fancyhead[HO]{%
 \global\AtPageToptrue%
 \begin{tikzpicture}[remember picture, overlay]
-  \fill[header_background] ([yshift=-0.5in]current page.north west)
+  \fill[color_header_footer_background] ([yshift=-0.5in]current page.north west)
   rectangle ([yshift=-0.9in]current page.north east);
 
-  \node[anchor=base east,white] at ([yshift=-0.764in,xshift=-0.7in]current page.north east) {
-    \scalebox{1.10}[1]{\headerFontWithFallback{$header_footer_font}{LetterSpace=-3.5} \fontsize{13pt}{0pt}\selectfont \customheader}
+  \node[anchor=base east] at ([yshift=-0.764in,xshift=-0.7in]current page.north east) {
+    \scalebox{1.10}[1]{\headerFontWithFallback{$header_footer_font}{LetterSpace=-3.5} \fontsize{13bp}{0bp}\selectfont \customheader}
   };
 \end{tikzpicture}%
 }
@@ -13,33 +13,33 @@
 \fancyhead[HE]{%
 \global\AtPageToptrue%
 \begin{tikzpicture}[remember picture, overlay]
-\fill[header_background] ([yshift=-0.5in]current page.north west)
+\fill[color_header_footer_background] ([yshift=-0.5in]current page.north west)
  rectangle ([yshift=-0.9in]current page.north east);
 
-\node[anchor=base west,white] at ([yshift=-0.764in,xshift=0.7in]current page.north west) {
-  \scalebox{1.10}[1]{\headerFontWithFallback{$header_footer_font}{LetterSpace=-3.5} \fontsize{13pt}{0pt}\selectfont The Swift Programming Language}
+\node[anchor=base west] at ([yshift=-0.764in,xshift=0.7in]current page.north west) {
+  \scalebox{1.10}[1]{\headerFontWithFallback{$header_footer_font}{LetterSpace=-3.5} \fontsize{13bp}{0bp}\selectfont The Swift Programming Language}
 };
 \end{tikzpicture}%
 }
 
 \fancyfoot[FO]{%
 \begin{tikzpicture}[remember picture, overlay]
-\fill[header_background] ([yshift=0.5in]current page.south west)
+\fill[color_header_footer_background] ([yshift=0.5in]current page.south west)
  rectangle ([yshift=0.9in]current page.south east);
 
-\node[anchor=east,white] at ([yshift=0.7in,xshift=-0.7in]current page.south east) {
-  \headerFontWithFallback{$header_footer_font}{} \fontsize{13pt}{0pt}\selectfont \thepage
+\node[anchor=east] at ([yshift=0.7in,xshift=-0.7in]current page.south east) {
+  \headerFontWithFallback{$header_footer_font}{} \fontsize{13bp}{0bp}\selectfont \thepage
 };
 \end{tikzpicture}%
 }
 
 \fancyfoot[FE]{%
 \begin{tikzpicture}[remember picture, overlay]
-\fill[header_background] ([yshift=0.5in]current page.south west)
+\fill[color_header_footer_background] ([yshift=0.5in]current page.south west)
  rectangle ([yshift=0.9in]current page.south east);
 
-\node[anchor=west,white] at ([yshift=0.7in,xshift=0.7in]current page.south west) {
-  \headerFontWithFallback{$header_footer_font}{} \fontsize{13pt}{0pt}\selectfont \thepage
+\node[anchor=west] at ([yshift=0.7in,xshift=0.7in]current page.south west) {
+  \headerFontWithFallback{$header_footer_font}{} \fontsize{13bp}{0bp}\selectfont \thepage
 };
 \end{tikzpicture}%
 }
@@ -48,22 +48,22 @@
   \fancyhf{}
   \fancyfoot[FO]{%
   \begin{tikzpicture}[remember picture, overlay]
-  \fill[header_background] ([yshift=0.5in]current page.south west)
+  \fill[color_header_footer_background] ([yshift=0.5in]current page.south west)
    rectangle ([yshift=0.9in]current page.south east);
 
-  \node[anchor=east,white] at ([yshift=0.7in,xshift=-0.7in]current page.south east) {
-    \headerFontWithFallback{$header_footer_font}{} \fontsize{13pt}{0pt}\selectfont \thepage
+  \node[anchor=east] at ([yshift=0.7in,xshift=-0.7in]current page.south east) {
+    \headerFontWithFallback{$header_footer_font}{} \fontsize{13bp}{0bp}\selectfont \thepage
   };
   \end{tikzpicture}%
   }
 
   \fancyfoot[FE]{%
   \begin{tikzpicture}[remember picture, overlay]
-  \fill[header_background] ([yshift=0.5in]current page.south west)
+  \fill[color_header_footer_background] ([yshift=0.5in]current page.south west)
    rectangle ([yshift=0.9in]current page.south east);
 
-  \node[anchor=west,white] at ([yshift=0.7in,xshift=0.7in]current page.south west) {
-    \headerFontWithFallback{$header_footer_font}{} \fontsize{13pt}{0pt}\selectfont \thepage
+  \node[anchor=west] at ([yshift=0.7in,xshift=0.7in]current page.south west) {
+    \headerFontWithFallback{$header_footer_font}{} \fontsize{13bp}{0bp}\selectfont \thepage
   };
   \end{tikzpicture}%
   }
@@ -74,11 +74,11 @@
   \ifoddpage
     % -- Odd page
     \hspace*{-2in}
-    \fcolorbox{hero_background}{hero_background}{%
+    \fcolorbox{color_article_background}{color_article_background}{%
       \begin{minipage}{\dimexpr\textwidth+2.3in\relax}
         \hspace{1.9in}
         \begin{minipage}[t]{0.7\textwidth}
-          \color{hero_text}
+          \color{color_text}
           \vspace*{${spacing_hero_top}}
           \TitleSection{#1}{#2}  % Title
           {\SubtitleStyle #3\par}  % Subtitle
@@ -89,9 +89,9 @@
   \else
     % -- Even page
     \hspace*{-0.53in}
-    \fcolorbox{hero_background}{hero_background}{%
+    \fcolorbox{color_article_background}{color_article_background}{%
       \begin{minipage}{\dimexpr\textwidth+2.3in\relax}
-        \color{hero_text}
+        \color{color_text}
         \hspace{0.4in}
         \begin{minipage}[t]{0.7\textwidth}
           \vspace*{${spacing_hero_top}}

--- a/src/swift_book_pdf/pdf/latex/templates/preamble.tex
+++ b/src/swift_book_pdf/pdf/latex/templates/preamble.tex
@@ -25,22 +25,22 @@
 % ----------------------------------------
 % Define custom colors
 % ----------------------------------------
-\definecolor{background}{RGB}{$background}
-\definecolor{text}{RGB}{$text}
-\definecolor{header_background}{RGB}{$header_background}
-\definecolor{header_text}{RGB}{$header_text}
-\definecolor{hero_background}{RGB}{$hero_background}
-\definecolor{hero_text}{RGB}{$hero_text}
-\definecolor{link}{RGB}{$link}
-\definecolor{aside_background}{RGB}{$aside_background}
-\definecolor{aside_text}{RGB}{$aside_text}
-\definecolor{aside_border}{RGB}{$aside_border}
-\definecolor{table_border}{RGB}{$table_border}
-\definecolor{code_border}{RGB}{$code_border}
-\definecolor{code_background}{RGB}{$code_background}
+\definecolor{color_text_background}{RGB}{$color_text_background}
+\definecolor{color_text}{RGB}{$color_text}
+\definecolor{color_article_background}{RGB}{$color_article_background}
+\definecolor{color_header_footer_background}{RGB}{$color_header_footer_background}
+\definecolor{color_header_footer_text}{RGB}{$color_header_footer_text}
+\definecolor{color_link}{RGB}{$color_link}
+\definecolor{color_grid}{RGB}{$color_grid}
+\definecolor{color_code_background}{RGB}{$color_code_background}
+\definecolor{color_code_plain}{RGB}{$color_code_plain}
+\definecolor{color_aside_note_background}{RGB}{$color_aside_note_background}
+\definecolor{color_aside_note_border}{RGB}{$color_aside_note_border}
+\definecolor{color_aside_note}{RGB}{$color_aside_note}
 
-\pagecolor{background}
-\color{text}
+\pagecolor{color_text_background}
+\color{color_text}
+
 % ----------------------------------------
 % Define fonts and small helpers
 % ----------------------------------------
@@ -89,7 +89,7 @@
 }
 
 \newcommand{\headerFontWithFallback}[2]{%
-  \fontspec{#1}[RawFeature={fallback=headerFallback},#2]\color{header_text}%
+  \fontspec{#1}[RawFeature={fallback=headerFallback},#2]\color{color_header_footer_text}%
 }
 
 \renewcommand{\footnotesize}{\monoFontWithFallback{$mono_font}\fontsize{${font_size_footnote}pt}{${font_size_footnote}pt}\selectfont}
@@ -368,7 +368,7 @@
     breakanywhere=true,
     breakbefore={ABCDEFGHIJKLMNOPQRSTUVWXYZ},
     breakafter={.,>)]:(\{},
-    breaksymbolleft={\raisebox{0.1ex}{\color{aside_border}\customsmall\ensuremath{\hookrightarrow}}},
+    breaksymbolleft={\raisebox{0.1ex}{\color{color_aside_note_border}\customsmall\ensuremath{\hookrightarrow}}},
     breaksymbolsepleft=0.3em,
     breakbeforesymbolpre={\,\customsmall\ensuremath{_\rfloor}},
     breakaftersymbolpre={\,\customsmall\ensuremath{_\rfloor}},
@@ -381,8 +381,9 @@
     framesep=0pt,
     escapeinside=||,
   },
-  colback=code_background,
-  colframe=code_border,
+  colback=color_code_background,
+  colframe=color_grid,
+  colupper=color_code_plain,
   boxrule=0.5pt,
   arc=4pt,
   top=${spacing_code_box_tb}, bottom=${spacing_code_box_tb},
@@ -390,7 +391,6 @@
   boxsep=0pt,
   before skip={\dimexpr\ifprecededbybox${spacing_box_before_preceded}\else${spacing_box_before}\fi},
   after skip=0in,
-  before lower=\color{text},
   after app={\global\precededbyboxtrue\global\precededbysectionfalse\global\precededbyparagraphfalse\global\precededbynotefalse\global\AtPageTopfalse},
 }
 
@@ -408,8 +408,9 @@
     frame=none,
     framesep=0pt,
   },
-  colback=code_background,
-  colframe=code_border,
+  colback=color_code_background,
+  colframe=color_grid,
+  colupper=color_code_plain,
   boxrule=0.5pt,
   arc=4pt,
   top=${spacing_code_box_tb}, bottom=${spacing_code_box_tb},
@@ -417,7 +418,6 @@
   boxsep=0pt,
   before skip={\dimexpr\ifprecededbybox${spacing_box_before_preceded}\else${spacing_box_before}\fi},
   after skip=0in,
-  colupper=text,
   after app={\global\precededbyboxtrue\global\precededbysectionfalse\global\precededbyparagraphfalse\global\precededbynotefalse\global\AtPageTopfalse},
 }
 
@@ -428,24 +428,24 @@
   enhanced,
   breakable,
   whole on next page if possible,
-  colback=aside_background,
+  colback=color_aside_note_background,
   arc=4pt,
-  borderline west={3pt}{0pt}{aside_border},
+  borderline west={3pt}{0pt}{color_aside_note_border},
   boxrule=0pt,
   frame empty,
   before skip={\dimexpr\ifprecededbybox${spacing_box_before_preceded}\else${spacing_box_before}\fi},
   after skip=0in,
   after app={\global\precededbyboxfalse\global\precededbysectionfalse\global\precededbyparagraphfalse\global\precededbynotetrue\global\AtPageTopfalse},
   left=${spacing_aside_left}, right=${spacing_aside_pad}, top=${spacing_aside_pad}, bottom=${spacing_aside_pad},
-  before upper={\raggedright\color{aside_text}},
+  before upper={\raggedright\color{color_text}},
 }
 
 
 \hypersetup{
-  colorlinks=true,    % Make links colored
-  linkcolor=link,     % Color of internal links
-  urlcolor=link,      % Color for URLs
-  pdfstartview=FitH,   % Ensure the view fits horizontally on page
+  colorlinks=true,          % Make links colored
+  linkcolor=color_link,     % Color of internal links
+  urlcolor=color_link,      % Color for URLs
+  pdfstartview=FitH,        % Ensure the view fits horizontally on page
   bookmarksdepth=4
 }
 


### PR DESCRIPTION
Align generated PDF LaTeX colors with Swift-DocC-Render CSS color tokens for page backgrounds, chapter heroes, links, tables, code blocks, and aside notes.

Closes #150, closes #149.