### PR TITLE
fix: handle LaTeX URL-fragments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix an issue where the header text in the generated PDF document could be misaligned between odd and even pages.
 - Fix an issue where Swift property scopes and unknown Highlight.js scopes could receive unsupported token styling instead of falling back to normal code text.
 - Fix an issue where multiline string escaped-newline continuations in Swift code could be highlighted differently from Swift-DocC-Render in generated HTML and Pygments tokens.
+- Fix an issue where generated PDF links with URL fragments could fail LaTeX compilation.
 
 ### Removed
 - Remove the bundled `Swift_logo_color_epub.png` asset, which is no longer referenced by the new SVG-based cover layout.

--- a/src/swift_book_pdf/pdf/latex/render/links.py
+++ b/src/swift_book_pdf/pdf/latex/render/links.py
@@ -74,10 +74,17 @@ def restore_markdown_links(
     """
     for token, (label, url) in markdown_links.items():
         formatted_label = format_label(label)
+        escaped_url = _escape_latex_url(url)
         replacement = (
-            f"\\href{{{url}}}{{{formatted_label}}}\\footnote{{\\url{{{url}}}}}"
+            f"\\href{{{escaped_url}}}{{{formatted_label}}}"
+            f"\\footnote{{\\url{{{escaped_url}}}}}"
             if mode == RenderingMode.PRINT
-            else f"\\href{{{url}}}{{{formatted_label}}}"
+            else f"\\href{{{escaped_url}}}{{{formatted_label}}}"
         )
         text = text.replace(token, replacement)
     return text
+
+
+def _escape_latex_url(url: str) -> str:
+    """Escape URL characters that are special in LaTeX macro arguments."""
+    return url.replace("#", r"\#")

--- a/tests/pdf/latex/test_inline.py
+++ b/tests/pdf/latex/test_inline.py
@@ -49,3 +49,21 @@ def test_apply_formatting_preserves_underscores_inside_link_urls() -> None:
         r"\footnote{\url{https://developer.apple.com/documentation/swift/warning(_:_:)}}"
         in rendered
     )
+
+
+def test_apply_formatting_escapes_hash_fragments_inside_link_urls() -> None:
+    source = (
+        "[Conforming to the Hashable Protocol]"
+        "(https://developer.apple.com/documentation/swift/hashable#2849490)"
+    )
+
+    rendered = apply_formatting(source, RenderingMode.PRINT)
+
+    assert (
+        r"\href{https://developer.apple.com/documentation/swift/hashable\#2849490}"
+        r"{Conforming to the Hashable Protocol}" in rendered
+    )
+    assert (
+        r"\footnote{\url{https://developer.apple.com/documentation/swift/hashable\#2849490}}"
+        in rendered
+    )


### PR DESCRIPTION
Fix an issue where generated PDF links with URL fragments could fail LaTeX compilation.