### PR TITLE
feat(pdf): increase body page width in gutter mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rework generated PDF table-of-contents chapter links to use DocC-style topic link blocks with aligned icons, subtitle indentation, and print page-reference leaders.
 - Align generated PDF inline image spacing with DocC content-node spacing and surrounding block-state handling.
 - Improve handling of special characters in generated PDF code blocks and inline text with PUA escapes.
+- Adjust the generated PDF LaTeX template geometry so guttered body content aligns more closely with header and footer text at the outer page edge.
 
 ### Fixed
 - Fix an issue where the header text in the generated PDF document could be misaligned between odd and even pages.

--- a/src/swift_book_pdf/pdf/latex/preamble/geometry.py
+++ b/src/swift_book_pdf/pdf/latex/preamble/geometry.py
@@ -28,7 +28,7 @@ def get_geometry_opts(paper_size: PaperSize, gutter: bool = True) -> str:
         Comma-separated geometry package options.
     """
     return {
-        PaperSize.A4: f"a4paper,{'inner=1.67in,outer=0.9in' if gutter else 'hmargin=1.285in'}",
-        PaperSize.LETTER: f"letterpaper,{'inner=1.9in,outer=0.9in' if gutter else 'hmargin=1.4in'}",
-        PaperSize.LEGAL: f"legalpaper,{'inner=1.9in,outer=0.9in' if gutter else 'hmargin=1.4in'}",
+        PaperSize.A4: f"a4paper,{'inner=1.67in,outer=0.75in' if gutter else 'hmargin=1.285in'}",
+        PaperSize.LETTER: f"letterpaper,{'inner=1.9in,outer=0.75in' if gutter else 'hmargin=1.4in'}",
+        PaperSize.LEGAL: f"legalpaper,{'inner=1.9in,outer=0.75in' if gutter else 'hmargin=1.4in'}",
     }[paper_size]


### PR DESCRIPTION
Adjust the generated PDF LaTeX template geometry so guttered body content aligns more closely with header and footer text at the outer page edge.