### PR TITLE
feat(pdf): adjust page margins in no-gutter mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Align generated PDF inline image spacing with DocC content-node spacing and surrounding block-state handling.
 - Improve handling of special characters in generated PDF code blocks and inline text with PUA escapes.
 - Adjust the generated PDF LaTeX template geometry so guttered body content aligns more closely with header and footer text at the outer page edge.
+- Align generated PDF no-gutter horizontal content margins with Swift-DocC-Render's full-width container padding instead of using paper-size-specific LaTeX margins.
 
 ### Fixed
 - Fix an issue where the header text in the generated PDF document could be misaligned between odd and even pages.

--- a/src/swift_book_pdf/pdf/latex/preamble/geometry.py
+++ b/src/swift_book_pdf/pdf/latex/preamble/geometry.py
@@ -15,20 +15,43 @@
 """LaTeX page geometry helpers."""
 
 from swift_book_pdf.pdf.config import PaperSize
+from swift_book_pdf.pdf.latex.styling.typography import get_css_dimension
 
 
-def get_geometry_opts(paper_size: PaperSize, gutter: bool = True) -> str:
+def get_geometry_opts(
+    paper_size: PaperSize,
+    gutter: bool = True,
+    body_font_size: float | None = None,
+) -> str:
     """Return LaTeX geometry options for the requested page layout.
 
     Args:
         paper_size: Output paper size.
         gutter: Whether to reserve extra inner margin for book binding.
+        body_font_size: Base paragraph font size in PDF points.
 
     Returns:
         Comma-separated geometry package options.
     """
+    if gutter:
+        layout_margins = {
+            PaperSize.A4: "inner=1.67in,outer=0.75in",
+            PaperSize.LETTER: "inner=1.9in,outer=0.75in",
+            PaperSize.LEGAL: "inner=1.9in,outer=0.75in",
+        }[paper_size]
+    else:
+        if body_font_size is None:
+            raise ValueError(
+                "body_font_size is required for no-gutter geometry"
+            )
+        no_gutter_hmargin = get_css_dimension(
+            "documentation_layout_full_width_container_padding_inline",
+            body_font_size,
+        )
+        layout_margins = f"hmargin={no_gutter_hmargin}"
+
     return {
-        PaperSize.A4: f"a4paper,{'inner=1.67in,outer=0.75in' if gutter else 'hmargin=1.285in'}",
-        PaperSize.LETTER: f"letterpaper,{'inner=1.9in,outer=0.75in' if gutter else 'hmargin=1.4in'}",
-        PaperSize.LEGAL: f"legalpaper,{'inner=1.9in,outer=0.75in' if gutter else 'hmargin=1.4in'}",
+        PaperSize.A4: f"a4paper,{layout_margins}",
+        PaperSize.LETTER: f"letterpaper,{layout_margins}",
+        PaperSize.LEGAL: f"legalpaper,{layout_margins}",
     }[paper_size]

--- a/src/swift_book_pdf/pdf/latex/preamble/template.py
+++ b/src/swift_book_pdf/pdf/latex/preamble/template.py
@@ -93,6 +93,7 @@ def build_preamble_substitutions(
         "geometry_opts": get_geometry_opts(
             config.doc_config.paper_size,
             config.doc_config.gutter,
+            config.doc_config.font_size,
         ),
         "fancyhead_fancyfoot_hero": header_footer_hero,
         "main_font": font_config.main_font,

--- a/src/swift_book_pdf/pdf/latex/styling/typography.py
+++ b/src/swift_book_pdf/pdf/latex/styling/typography.py
@@ -40,6 +40,7 @@ DOCC_RENDER_LENGTHS = {
     "article_hero_intro_line_height": "29px",
     "article_hero_padding_top": "30px",
     "article_hero_padding_bottom": "30px",
+    "documentation_layout_full_width_container_padding_inline": "80px",
     "documentation_topic_title_margin_bottom": "12px",
     "documentation_topic_content_table_title_font_size": "32px",
     "documentation_topic_content_table_title_line_height": "36px",


### PR DESCRIPTION
enhancement

Align generated PDF no-gutter horizontal content margins with Swift-DocC-Render's full-width container padding instead of using paper-size-specific LaTeX margins.