### PR TITLE
feat(pdf): default to no-gutter in digital mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve handling of special characters in generated PDF code blocks and inline text with PUA escapes.
 - Adjust the generated PDF LaTeX template geometry so guttered body content aligns more closely with header and footer text at the outer page edge.
 - Align generated PDF no-gutter horizontal content margins with Swift-DocC-Render's full-width container padding instead of using paper-size-specific LaTeX margins.
+- Default generated PDF digital-mode output to no book gutter while preserving the guttered default for print-mode output.
 
 ### Fixed
 - Fix an issue where the header text in the generated PDF document could be misaligned between odd and even pages.

--- a/src/swift_book_pdf/pdf/cli/config.py
+++ b/src/swift_book_pdf/pdf/cli/config.py
@@ -21,7 +21,6 @@ from swift_book_pdf.cli.source import resolve_cli_build_source
 from swift_book_pdf.pdf.backend import PDFBackend, PDFBackendConfigInput
 from swift_book_pdf.pdf.config import (
     DEFAULT_BODY_FONT_SIZE,
-    DEFAULT_GUTTER,
     Appearance,
     PaperSize,
     PDFConfig,
@@ -51,13 +50,28 @@ def build_doc_config(
     Returns:
         PDF document layout configuration.
     """
+    rendering_mode = RenderingMode(mode)
     return PDFDocumentConfig(
-        mode=RenderingMode(mode),
+        mode=rendering_mode,
         paper_size=PaperSize(paper),
-        gutter=DEFAULT_GUTTER if gutter is None else gutter,
+        gutter=_default_gutter_for_mode(rendering_mode)
+        if gutter is None
+        else gutter,
         font_size=(DEFAULT_BODY_FONT_SIZE if font_size is None else font_size),
         appearance=Appearance.DARK if dark else Appearance.LIGHT,
     )
+
+
+def _default_gutter_for_mode(mode: RenderingMode) -> bool:
+    """Return the implicit gutter setting for a rendering mode.
+
+    Args:
+        mode: Resolved PDF rendering mode.
+
+    Returns:
+        Whether gutter should be enabled when the CLI flag is omitted.
+    """
+    return mode == RenderingMode.PRINT
 
 
 def build_content_selection(

--- a/tests/pdf/test_config.py
+++ b/tests/pdf/test_config.py
@@ -13,7 +13,10 @@
 # limitations under the License.
 
 from swift_book_pdf.core.config import ResolvedBuildSource
-from swift_book_pdf.pdf.cli.config import build_content_selection
+from swift_book_pdf.pdf.cli.config import (
+    build_content_selection,
+    build_doc_config,
+)
 from swift_book_pdf.pdf.config import PDFContentSelection, PDFDocumentConfig
 from swift_book_pdf.pdf.latex.config import LaTeXConfig, LaTeXPDFConfig
 from swift_book_pdf.pdf.latex.fonts.resolver import LaTeXFontConfig
@@ -86,6 +89,42 @@ def test_latex_pdf_config_formats_build_error_details() -> None:
     assert "Unicode font(s): Noto Sans Symbols 2 (custom font(s))" in (
         config.build_error_details()
     )
+
+
+def test_build_doc_config_defaults_to_no_gutter_for_digital_mode() -> None:
+    config = build_doc_config(
+        mode="digital",
+        paper="letter",
+        dark=False,
+        gutter=None,
+        font_size=None,
+    )
+
+    assert config.gutter is False
+
+
+def test_build_doc_config_defaults_to_gutter_for_print_mode() -> None:
+    config = build_doc_config(
+        mode="print",
+        paper="letter",
+        dark=False,
+        gutter=None,
+        font_size=None,
+    )
+
+    assert config.gutter is True
+
+
+def test_build_doc_config_uses_explicit_gutter_override() -> None:
+    config = build_doc_config(
+        mode="digital",
+        paper="letter",
+        dark=False,
+        gutter=True,
+        font_size=None,
+    )
+
+    assert config.gutter is True
 
 
 def test_pdf_content_selection_rejects_conflicting_selectors() -> None:


### PR DESCRIPTION
Default generated PDF digital-mode output to no book gutter while preserving the guttered default for print-mode output.