### PR TITLE
feat(pdf): allow code block font adjustments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add new `--only-toc` flag to `swift-book-pdf` to generate only the table of contents.
 - Add new `--only-chapter` flag to `swift-book-pdf` to generate a single chapter by DocC tag (`<doc:TheBasics>`) or file stem (`TheBasics`).
 - Add Swift-DocC-Render-compatible word break opportunities to generated PDF inline code spans.
+- Add `--code-font-size` to `swift-book-pdf` to adjust code block typography independently from the base paragraph font size.
 
 ### Changed
 - Redesign generated EPUB cover artwork and rendered cover text for release and beta editions, with new templates, edition-specific colors, and adjusted version-label spacing and positioning.

--- a/src/swift_book_pdf/pdf/cli/command.py
+++ b/src/swift_book_pdf/pdf/cli/command.py
@@ -78,6 +78,7 @@ def pdf(  # noqa: PLR0913
     only_toc: bool,
     only_chapter: str | None,
     font_size: float | None,
+    code_font_size: float | None,
     dark: bool,
     dangerously_skip_legal_notices: bool,
     gutter: bool | None,
@@ -101,6 +102,7 @@ def pdf(  # noqa: PLR0913
         only_toc: Whether to render only the table of contents page.
         only_chapter: Optional document tag or file stem for one chapter.
         font_size: Optional base paragraph font size.
+        code_font_size: Optional fenced code listing font size.
         dark: Whether dark mode should be rendered.
         dangerously_skip_legal_notices: Whether generated notices are omitted.
         gutter: Optional gutter override.
@@ -122,6 +124,7 @@ def pdf(  # noqa: PLR0913
         dark=dark,
         gutter=gutter,
         font_size=font_size,
+        code_font_size=code_font_size,
     )
     content_selection = pdf_config.build_content_selection(
         only_toc=only_toc,

--- a/src/swift_book_pdf/pdf/cli/config.py
+++ b/src/swift_book_pdf/pdf/cli/config.py
@@ -30,13 +30,14 @@ from swift_book_pdf.pdf.config import (
 )
 
 
-def build_doc_config(
+def build_doc_config(  # noqa: PLR0913
     *,
     mode: str,
     paper: str,
     dark: bool,
     gutter: bool | None,
     font_size: float | None,
+    code_font_size: float | None = None,
 ) -> PDFDocumentConfig:
     """Build PDF document layout configuration from CLI options.
 
@@ -46,6 +47,7 @@ def build_doc_config(
         dark: Whether dark mode should be rendered.
         gutter: Optional gutter override.
         font_size: Optional base paragraph font size.
+        code_font_size: Optional fenced code listing font size.
 
     Returns:
         PDF document layout configuration.
@@ -58,6 +60,7 @@ def build_doc_config(
         if gutter is None
         else gutter,
         font_size=(DEFAULT_BODY_FONT_SIZE if font_size is None else font_size),
+        code_font_size=code_font_size,
         appearance=Appearance.DARK if dark else Appearance.LIGHT,
     )
 

--- a/src/swift_book_pdf/pdf/cli/options.py
+++ b/src/swift_book_pdf/pdf/cli/options.py
@@ -127,8 +127,14 @@ def pdf_typography_options(func: OptionTarget) -> OptionTarget:
             "--font-size",
             type=float,
             default=None,
-            help="Base paragraph font size in points. All other font sizes scale proportionally",
+            help="Base paragraph font size in points. Other font sizes scale proportionally unless overridden",
             show_default=f"{DEFAULT_BODY_FONT_SIZE:g}",
+        ),
+        click.option(
+            "--code-font-size",
+            type=float,
+            default=None,
+            help="Code block font size in points",
         ),
     )
     return apply_options(func, decorators)

--- a/src/swift_book_pdf/pdf/config.py
+++ b/src/swift_book_pdf/pdf/config.py
@@ -80,6 +80,7 @@ class PDFDocumentConfig:
         gutter: Whether the book gutter should be rendered.
         font_size: Base paragraph font size in points.
         appearance: Light or dark rendering appearance.
+        code_font_size: Optional fenced code listing font size in points.
     """
 
     mode: RenderingMode = DEFAULT_RENDERING_MODE
@@ -97,14 +98,19 @@ class PDFDocumentConfig:
     appearance: Appearance = DEFAULT_APPEARANCE
     """Light or dark rendering appearance."""
 
+    code_font_size: float | None = None
+    """Optional fenced code listing font size in points."""
+
     def __post_init__(self) -> None:
         """Validate the resolved document configuration.
 
         Raises:
-            ValueError: If `font_size` is not positive.
+            ValueError: If a font size is not positive.
         """
         if self.font_size <= 0:
             raise ValueError("Font size must be a positive number.")
+        if self.code_font_size is not None and self.code_font_size <= 0:
+            raise ValueError("Code font size must be a positive number.")
 
 
 @dataclass(frozen=True)
@@ -181,6 +187,9 @@ class PDFConfig(BaseBuildConfig, ABC):
                 f"Appearance: {doc_config.appearance}",
                 f"Book Gutter: {doc_config.gutter}",
                 f"Font size: {doc_config.font_size}pt",
+                f"Code font size: {doc_config.code_font_size}pt"
+                if doc_config.code_font_size is not None
+                else "Code font size: scaled",
                 f"Content: {format_content_selection(self.content_selection)}",
                 f"Build target: {'tex' if self.save_tex else 'pdf'}",
                 f"Build files: {self.intermediates_path or 'temporary'}",

--- a/src/swift_book_pdf/pdf/latex/preamble/template.py
+++ b/src/swift_book_pdf/pdf/latex/preamble/template.py
@@ -21,7 +21,7 @@ from swift_book_pdf.pdf.latex.preamble.geometry import get_geometry_opts
 from swift_book_pdf.pdf.latex.styling.colors import get_document_colors
 from swift_book_pdf.pdf.latex.styling.typography import (
     compute_typography_variables,
-    get_css_points,
+    get_code_listing_font_size_points,
 )
 from swift_book_pdf.pdf.latex.templating import load_latex_template
 
@@ -59,10 +59,13 @@ def build_preamble_substitutions(
         config.doc_config.mode, config.doc_config.appearance
     )
 
-    template_vars = compute_typography_variables(config.doc_config.font_size)
-    code_block_font_size = get_css_points(
-        "font_style_documentation_code_listing_font_size",
+    template_vars = compute_typography_variables(
         config.doc_config.font_size,
+        code_font_size=config.doc_config.code_font_size,
+    )
+    code_block_font_size = get_code_listing_font_size_points(
+        config.doc_config.font_size,
+        config.doc_config.code_font_size,
     )
     template_vars["breakindent_minted"] = f"{3.8 * code_block_font_size:.2f}bp"
 

--- a/src/swift_book_pdf/pdf/latex/styling/typography.py
+++ b/src/swift_book_pdf/pdf/latex/styling/typography.py
@@ -216,16 +216,66 @@ def format_dimension(value: float, unit: str) -> str:
     return f"{format_number(value)}{unit}"
 
 
-def compute_typography_variables(body_font_size: float) -> dict[str, str]:
+CODE_LISTING_FONT_SIZE_KEY = "font_style_documentation_code_listing_font_size"
+CODE_LISTING_LINE_HEIGHT_KEY = (
+    "font_style_documentation_code_listing_line_height"
+)
+
+
+def get_code_listing_font_size_points(
+    body_font_size: float,
+    code_font_size: float | None = None,
+) -> float:
+    """Return the resolved fenced code listing font size in PDF points.
+
+    Args:
+        body_font_size: Base paragraph font size in PDF points.
+        code_font_size: Optional fenced code listing font size override.
+
+    Returns:
+        Fenced code listing font size in PDF points.
+    """
+    if code_font_size is not None:
+        return code_font_size
+    return get_css_points(CODE_LISTING_FONT_SIZE_KEY, body_font_size)
+
+
+def compute_typography_variables(
+    body_font_size: float,
+    *,
+    code_font_size: float | None = None,
+) -> dict[str, str]:
     """Compute DocC Render-shaped variables for LaTeX templates.
 
     Args:
         body_font_size: Base paragraph font size in PDF points.
+        code_font_size: Optional fenced code listing font size override.
 
     Returns:
         Template variables keyed by DocC Render role names in snake case.
     """
-    return {
+    variables = {
         key: get_css_dimension(key, body_font_size)
         for key in DOCC_RENDER_LENGTHS
     }
+    if code_font_size is not None:
+        default_code_font_size = get_css_points(
+            CODE_LISTING_FONT_SIZE_KEY,
+            body_font_size,
+        )
+        default_code_line_height = get_css_points(
+            CODE_LISTING_LINE_HEIGHT_KEY,
+            body_font_size,
+        )
+        code_line_height = (
+            default_code_line_height * code_font_size / default_code_font_size
+        )
+        variables[CODE_LISTING_FONT_SIZE_KEY] = format_dimension(
+            code_font_size,
+            LATEX_PDF_POINT_UNIT,
+        )
+        variables[CODE_LISTING_LINE_HEIGHT_KEY] = format_dimension(
+            code_line_height,
+            LATEX_PDF_POINT_UNIT,
+        )
+    return variables

--- a/tests/pdf/latex/test_typography.py
+++ b/tests/pdf/latex/test_typography.py
@@ -29,8 +29,33 @@ def test_default_line_height_and_code_padding_match_docc_css() -> None:
     variables = compute_typography_variables(DEFAULT_BODY_FONT_SIZE)
 
     assert variables["font_style_body_line_height"] == "14.0625bp"
+    assert (
+        variables["font_style_documentation_code_listing_font_size"]
+        == "8.4375bp"
+    )
+    assert (
+        variables["font_style_documentation_code_listing_line_height"]
+        == "14.0625bp"
+    )
     assert variables["code_block_style_elements_padding_block"] == "4.5bp"
     assert variables["code_block_style_elements_padding_inline"] == "7.875bp"
+
+
+def test_code_font_size_override_only_changes_code_listing_size() -> None:
+    variables = compute_typography_variables(
+        DEFAULT_BODY_FONT_SIZE,
+        code_font_size=9,
+    )
+
+    assert variables["font_style_body_font_size"] == "9.5625bp"
+    assert variables["content_node_code_voice_font_size"] == "9.5625bp"
+    assert (
+        variables["font_style_documentation_code_listing_font_size"] == "9bp"
+    )
+    assert (
+        variables["font_style_documentation_code_listing_line_height"]
+        == "15bp"
+    )
 
 
 def test_article_route_tokens_match_docc_css() -> None:

--- a/tests/pdf/test_config.py
+++ b/tests/pdf/test_config.py
@@ -127,6 +127,28 @@ def test_build_doc_config_uses_explicit_gutter_override() -> None:
     assert config.gutter is True
 
 
+def test_build_doc_config_keeps_code_font_size_override() -> None:
+    config = build_doc_config(
+        mode="digital",
+        paper="letter",
+        dark=False,
+        gutter=None,
+        font_size=None,
+        code_font_size=8.5,
+    )
+
+    assert config.code_font_size == 8.5
+
+
+def test_pdf_document_config_rejects_non_positive_code_font_size() -> None:
+    try:
+        PDFDocumentConfig(code_font_size=0)
+    except ValueError as exc:
+        assert "Code font size must be a positive number" in str(exc)
+    else:
+        raise AssertionError("Expected invalid code font size")
+
+
 def test_pdf_content_selection_rejects_conflicting_selectors() -> None:
     try:
         PDFContentSelection(only_toc=True, only_chapter="GuidedTour")


### PR DESCRIPTION
Add --code-font-size to swift-book-pdf to adjust code block typography independently from the base paragraph font size.